### PR TITLE
feat: re-structuring of register-oracle cmd

### DIFF
--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -1,0 +1,8 @@
+package flags
+
+const (
+	FlagTrustedBlockHeight = "trusted-block-height"
+	FlagTrustedBlockHash   = "trusted-block-hash"
+	FlagAccNum             = "acc-num"
+	FlagIndex              = "index"
+)

--- a/cmd/doracled/cmd/register_oracle.go
+++ b/cmd/doracled/cmd/register_oracle.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"encoding/base64"
 	"fmt"
 	"github.com/medibloc/panacea-doracle/client/flags"
 	"github.com/medibloc/panacea-doracle/config"
+	"github.com/medibloc/panacea-doracle/panacea"
 	"github.com/medibloc/panacea-doracle/server/regoracle"
 	"github.com/medibloc/panacea-doracle/server/service"
 	"github.com/spf13/cobra"
@@ -30,7 +32,21 @@ func RegisterOracleCmd() *cobra.Command {
 				return fmt.Errorf("failed to init logger: %w", err)
 			}
 
-			svc, err := service.New(cmd, conf)
+			// get trusted block information
+			trustedBlockInfo, err := getTrustedBlockInfo(cmd)
+			if err != nil {
+				log.Errorf("failed to get trusted block info: %v", err)
+				return fmt.Errorf("failed to get trusted block info: %w", err)
+			}
+
+			// get oracle account from mnemonic.
+			oracleAccount, err := getOracleAccount(cmd, conf.OracleMnemonic)
+			if err != nil {
+				log.Errorf("failed to get oracle account from mnemonic: %v", err)
+				return fmt.Errorf("failed to get oracle account from mnemonic: %w", err)
+			}
+
+			svc, err := service.New(conf, oracleAccount, trustedBlockInfo)
 			if err != nil {
 				log.Errorf("failed to create a new service: %v", err)
 				return err
@@ -79,4 +95,56 @@ func RegisterOracleCmd() *cobra.Command {
 	_ = cmd.MarkFlagRequired(flags.FlagTrustedBlockHash)
 
 	return cmd
+}
+
+// getTrustedBlockInfo gets trusted block height and hash from cmd flags
+func getTrustedBlockInfo(cmd *cobra.Command) (*panacea.TrustedBlockInfo, error) {
+	trustedBlockHeight, err := cmd.Flags().GetInt64(flags.FlagTrustedBlockHeight)
+	if err != nil {
+		return nil, err
+	}
+	if trustedBlockHeight == 0 {
+		return nil, fmt.Errorf("trusted block height cannot be zero")
+	}
+
+	trustedBlockHashStr, err := cmd.Flags().GetString(flags.FlagTrustedBlockHash)
+	if err != nil {
+		return nil, err
+	}
+	if trustedBlockHashStr == "" {
+		return nil, fmt.Errorf("trusted block hash cannot be empty")
+	}
+
+	trustedBlockHash, err := base64.StdEncoding.DecodeString(trustedBlockHashStr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &panacea.TrustedBlockInfo{
+		TrustedBlockHeight: trustedBlockHeight,
+		TrustedBlockHash:   trustedBlockHash,
+	}, nil
+}
+
+// getOracleAccount gets an oracle account from mnemonic.
+// The account is equal to one that is registered as validator.
+// You can set account number and index optionally.
+// The default value is 0 for both account number and index
+func getOracleAccount(cmd *cobra.Command, mnemonic string) (*panacea.OracleAccount, error) {
+	accNum, err := cmd.Flags().GetUint32(flags.FlagAccNum)
+	if err != nil {
+		return &panacea.OracleAccount{}, err
+	}
+
+	index, err := cmd.Flags().GetUint32(flags.FlagIndex)
+	if err != nil {
+		return &panacea.OracleAccount{}, err
+	}
+
+	oracleAccount, err := panacea.NewOracleAccount(mnemonic, accNum, index)
+	if err != nil {
+		return &panacea.OracleAccount{}, err
+	}
+
+	return oracleAccount, nil
 }

--- a/cmd/doracled/cmd/start.go
+++ b/cmd/doracled/cmd/start.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"github.com/medibloc/panacea-doracle/config"
-	"github.com/medibloc/panacea-doracle/server"
 	"github.com/spf13/cobra"
 	"time"
 
@@ -23,7 +22,7 @@ var startCmd = &cobra.Command{
 			return fmt.Errorf("failed to init logger: %w", err)
 		}
 
-		return server.Run(conf)
+		return nil
 	},
 }
 

--- a/crypto/key.go
+++ b/crypto/key.go
@@ -13,6 +13,10 @@ func NewPrivKey() (*btcec.PrivateKey, error) {
 	return btcec.NewPrivateKey(btcec.S256())
 }
 
+func PrivKeyFromBytes(privKeyBz []byte) (*btcec.PrivateKey, *btcec.PublicKey) {
+	return btcec.PrivKeyFromBytes(btcec.S256(), privKeyBz)
+}
+
 func GeneratePrivateKeyFromMnemonic(mnemonic string, coinType, accNum, index uint32) (secp256k1.PrivKey, error) {
 	if !bip39.IsMnemonicValid(mnemonic) {
 		return nil, fmt.Errorf("invalid mnemonic")

--- a/panacea/grpc_client.go
+++ b/panacea/grpc_client.go
@@ -94,7 +94,7 @@ func (c *GrpcClient) GetOracleRegistration(oracleAddr, uniqueID string) (*oracle
 	}
 	response, err := client.OracleRegistration(ctx, reqMsg)
 	if err != nil {
-		return &oracletypes.OracleRegistration{}, err
+		return nil, err
 	}
 
 	return response.OracleRegistration, nil

--- a/panacea/grpc_client.go
+++ b/panacea/grpc_client.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/std"
 	"github.com/cosmos/cosmos-sdk/types/tx"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	oracletypes "github.com/medibloc/panacea-core/v2/x/oracle/types"
 	"github.com/medibloc/panacea-doracle/config"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
@@ -17,8 +18,9 @@ type GrpcClientI interface {
 	Close() error
 	GetInterfaceRegistry() sdk.InterfaceRegistry
 	GetChainID() string
-	BroadcastTx(txBytes []byte) (*tx.BroadcastTxResponse, error)
-	GetAccount(panaceaAddr string) (authtypes.AccountI, error)
+	BroadcastTx([]byte) (*tx.BroadcastTxResponse, error)
+	GetAccount(string) (authtypes.AccountI, error)
+	GetOracleRegistration(string, string) (*oracletypes.OracleRegistration, error)
 }
 
 var _ GrpcClientI = (*GrpcClient)(nil)
@@ -79,6 +81,23 @@ func (c *GrpcClient) GetAccount(panaceaAddr string) (authtypes.AccountI, error) 
 		return nil, fmt.Errorf("failed to unpack account info: %w", err)
 	}
 	return acc, nil
+}
+
+func (c *GrpcClient) GetOracleRegistration(oracleAddr, uniqueID string) (*oracletypes.OracleRegistration, error) {
+	client := oracletypes.NewQueryClient(c.conn)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	reqMsg := &oracletypes.QueryOracleRegistrationRequest{
+		UniqueId: uniqueID,
+		Address:  oracleAddr,
+	}
+	response, err := client.OracleRegistration(ctx, reqMsg)
+	if err != nil {
+		return &oracletypes.OracleRegistration{}, err
+	}
+
+	return response.OracleRegistration, nil
 }
 
 func (c *GrpcClient) BroadcastTx(txBytes []byte) (*tx.BroadcastTxResponse, error) {

--- a/panacea/query_client.go
+++ b/panacea/query_client.go
@@ -27,6 +27,11 @@ const (
 	blockPeriod = 6 * time.Second
 )
 
+type TrustedBlockInfo struct {
+	TrustedBlockHeight int64
+	TrustedBlockHash   []byte
+}
+
 type QueryClient struct {
 	RpcClient         *rpchttp.HTTP
 	LightClient       *light.Client

--- a/server/regoracle/server.go
+++ b/server/regoracle/server.go
@@ -108,7 +108,7 @@ func (srv *Server) createRegistration() error {
 	uniqueIDStr := base64.StdEncoding.EncodeToString(report.UniqueID)
 
 	// sign and broadcast to Panacea
-	msgRegisterOracle := oracletypes.NewMsgRegisterOracle(uniqueIDStr, srv.OracleAccount.GetAddress(), nodePubKey, nodePubKeyRemoteReport, srv.TrustedHeight, srv.TrustedHash)
+	msgRegisterOracle := oracletypes.NewMsgRegisterOracle(uniqueIDStr, srv.OracleAccount.GetAddress(), nodePubKey, nodePubKeyRemoteReport, srv.TrustedBlockInfo.TrustedBlockHeight, srv.TrustedBlockInfo.TrustedBlockHash)
 
 	txBuilder := panacea.NewTxBuilder(srv.PanaceaClient)
 

--- a/server/regoracle/server.go
+++ b/server/regoracle/server.go
@@ -49,7 +49,10 @@ func (srv *Server) Close() error {
 // continueRegistration continues the oracle registration process using the existing node key
 func (srv *Server) continueRegistration() error {
 	// get existing node key
-	nodePrivKeyBz, _ := sgx.UnsealFromFile(nodePrivKeyPath)
+	nodePrivKeyBz, err := sgx.UnsealFromFile(nodePrivKeyPath)
+	if err != nil {
+		return err
+	}
 	_, nodePubKey := crypto.PrivKeyFromBytes(nodePrivKeyBz)
 
 	// get unique ID

--- a/server/regoracle/server.go
+++ b/server/regoracle/server.go
@@ -1,0 +1,168 @@
+package regoracle
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/edgelesssys/ego/enclave"
+	oracletypes "github.com/medibloc/panacea-core/v2/x/oracle/types"
+	"github.com/medibloc/panacea-doracle/crypto"
+	"github.com/medibloc/panacea-doracle/panacea"
+	"github.com/medibloc/panacea-doracle/server/service"
+	"github.com/medibloc/panacea-doracle/sgx"
+	"github.com/medibloc/panacea-doracle/types"
+	log "github.com/sirupsen/logrus"
+	tos "github.com/tendermint/tendermint/libs/os"
+	"os"
+	"path/filepath"
+)
+
+var nodePrivKeyPath string
+
+type Server struct {
+	*service.Service
+}
+
+func NewServer(svc *service.Service) *Server {
+	return &Server{
+		Service: svc,
+	}
+}
+
+func (srv *Server) Run() error {
+	// if node key exists, continue the process of registration with the existing key
+	if tos.FileExists(nodePrivKeyPath) {
+		return srv.continueRegistration()
+	}
+
+	// if there is no node private key, create a new node key and request OracleRegistration
+	return srv.createRegistration()
+}
+
+func (srv *Server) Close() error {
+	return nil
+}
+
+// continueRegistration continues the oracle registration process using the existing node key
+func (srv *Server) continueRegistration() error {
+	// get existing node key
+	nodePrivKeyBz, _ := sgx.UnsealFromFile(nodePrivKeyPath)
+	_, nodePubKey := crypto.PrivKeyFromBytes(nodePrivKeyBz)
+
+	// get unique ID
+	selfEnclaveInfo, err := sgx.GetSelfEnclaveInfo()
+	if err != nil {
+		return err
+	}
+
+	uniqueID := base64.StdEncoding.EncodeToString(selfEnclaveInfo.UniqueID)
+
+	// get oracle registration from Panacea.
+	// TODO: Should be replaced with light client query for data verification
+	oracleRegistration, err := srv.PanaceaClient.GetOracleRegistration(srv.OracleAccount.GetAddress(), uniqueID)
+	if err != nil {
+		return err
+	}
+
+	// check if the same node key is used for oracle registration
+	if !bytes.Equal(oracleRegistration.NodePubKey, nodePubKey.SerializeCompressed()) {
+		return errors.New("the existing node key is different from the one used in oracle registration. if you want to re-request RegisterOracle, delete the existing node_priv_key.sealed file and rerun register-oracle cmd")
+	}
+
+	// handle differently depending on the status of oracle registration
+	switch oracleRegistration.Status {
+	case oracletypes.ORACLE_REGISTRATION_STATUS_VOTING_PERIOD:
+		// in voting period
+		// subscribe an event for OracleRegistrationCompleted
+	case oracletypes.ORACLE_REGISTRATION_STATUS_PASSED:
+		// oracle registration vote already passed
+		// check if oracle private key exists or not
+		// if exists, return nil. no need to do register-oracle
+		// else, get encryptedOraclePrivKey from Panacea and decrypt and SealToFile it
+	case oracletypes.ORACLE_REGISTRATION_STATUS_REJECTED:
+		// oracle registration vote rejected
+		return errors.New("the request for oracle registration is rejected. please delete the existing node key and retry with a new one")
+	default:
+		return errors.New("invalid oracle registration status")
+	}
+
+	return nil
+}
+
+// createRegistration generates a random node key pair and request for oracle registration to Panacea
+func (srv *Server) createRegistration() error {
+	//generate node key and its remote report
+	nodePubKey, nodePubKeyRemoteReport, err := generateNodeKey()
+	if err != nil {
+		log.Errorf("failed to generate node key pair: %v", err)
+		return err
+	}
+
+	report, _ := enclave.VerifyRemoteReport(nodePubKeyRemoteReport)
+	uniqueIDStr := base64.StdEncoding.EncodeToString(report.UniqueID)
+
+	// sign and broadcast to Panacea
+	msgRegisterOracle := oracletypes.NewMsgRegisterOracle(uniqueIDStr, srv.OracleAccount.GetAddress(), nodePubKey, nodePubKeyRemoteReport, srv.TrustedHeight, srv.TrustedHash)
+
+	txBuilder := panacea.NewTxBuilder(srv.PanaceaClient)
+
+	defaultFeeAmount, _ := sdk.ParseCoinsNormalized(srv.Conf.Panacea.DefaultFeeAmount)
+
+	txBytes, err := txBuilder.GenerateSignedTxBytes(srv.OracleAccount.GetPrivKey(), srv.Conf.Panacea.DefaultGasLimit, defaultFeeAmount, msgRegisterOracle)
+	if err != nil {
+		log.Errorf("failed to generate signed Tx bytes: %v", err)
+		return err
+	}
+
+	response, err := srv.PanaceaClient.BroadcastTx(txBytes)
+	if err != nil {
+		log.Errorf("failed to broadcast transaction: %v", err)
+		return err
+	}
+
+	// if tx fails,
+	if response.TxResponse.Code != 0 {
+		log.Errorf("transaction for registration of oracle failed: %v", response.TxResponse.Logs)
+		return fmt.Errorf("transaction failed")
+	}
+
+	// if tx success, let's wait for vote. maybe use WaitGroup?
+	// subscriber := event.NewSubscriber(event.RegisterOracleCompleted)
+	// subscribe event and handle it
+	// defer subscriber.Close()
+	return nil
+}
+
+// generateNodeKey generates random node key and its remote report
+// And the generated private key is sealed and stored
+func generateNodeKey() ([]byte, []byte, error) {
+	nodePrivKey, err := crypto.NewPrivKey()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if err := sgx.SealToFile(nodePrivKey.Serialize(), nodePrivKeyPath); err != nil {
+		return nil, nil, err
+	}
+
+	nodePubKey := nodePrivKey.PubKey().SerializeCompressed()
+	nodePubKeyHash := sha256.Sum256(nodePubKey)
+	nodeKeyRemoteReport, err := sgx.GenerateRemoteReport(nodePubKeyHash[:])
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return nodePubKey, nodeKeyRemoteReport, nil
+}
+
+func init() {
+	userHomeDir, err := os.UserHomeDir()
+	if err != nil {
+		panic(err)
+	}
+
+	nodePrivKeyPath = filepath.Join(userHomeDir, types.DefaultDoracleDir, types.DefaultNodePrivKeyName)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/medibloc/panacea-doracle/config"
-	"github.com/medibloc/panacea-doracle/server/service"
 	"net/http"
 	"os"
 	"os/signal"
@@ -15,12 +14,6 @@ import (
 )
 
 func Run(conf *config.Config) error {
-	svc, err := service.New(conf)
-	if err != nil {
-		return fmt.Errorf("failed to create service: %w", err)
-	}
-	defer svc.Close()
-
 	server := &http.Server{
 		Addr:         conf.ListenAddr,
 		WriteTimeout: 15 * time.Second,

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -1,98 +1,32 @@
 package service
 
 import (
-	"encoding/base64"
 	"fmt"
-	"github.com/medibloc/panacea-doracle/client/flags"
 	"github.com/medibloc/panacea-doracle/config"
 	"github.com/medibloc/panacea-doracle/panacea"
-	"github.com/spf13/cobra"
 )
 
 type Service struct {
-	Conf          *config.Config
-	OracleAccount *panacea.OracleAccount
-	TrustedHeight int64
-	TrustedHash   []byte
-	PanaceaClient panacea.GrpcClientI
+	Conf             *config.Config
+	OracleAccount    *panacea.OracleAccount
+	TrustedBlockInfo *panacea.TrustedBlockInfo
+	PanaceaClient    panacea.GrpcClientI
 }
 
-func New(cmd *cobra.Command, conf *config.Config) (*Service, error) {
-	// get trusted block information
-	height, hash, err := getTrustedBlockInfo(cmd)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get trusted block info: %w", err)
-	}
-
-	// get oracle account from mnemonic.
-	oracleAccount, err := getOracleAccount(cmd, conf.OracleMnemonic)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get oracle account from mnemonic: %w", err)
-	}
-
+func New(conf *config.Config, oracleAccount *panacea.OracleAccount, trustedBlockInfo *panacea.TrustedBlockInfo) (*Service, error) {
 	panaceaClient, err := panacea.NewGrpcClient(conf)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Panacea gRPC client: %w", err)
 	}
 
 	return &Service{
-		Conf:          conf,
-		OracleAccount: oracleAccount,
-		TrustedHeight: height,
-		TrustedHash:   hash,
-		PanaceaClient: panaceaClient,
+		Conf:             conf,
+		OracleAccount:    oracleAccount,
+		TrustedBlockInfo: trustedBlockInfo,
+		PanaceaClient:    panaceaClient,
 	}, nil
 }
 
 func (svc *Service) Close() {
 	_ = svc.PanaceaClient.Close()
-}
-
-// getTrustedBlockInfo gets trusted block height and hash from cmd flags
-func getTrustedBlockInfo(cmd *cobra.Command) (int64, []byte, error) {
-	trustedBlockHeight, err := cmd.Flags().GetInt64(flags.FlagTrustedBlockHeight)
-	if err != nil {
-		return 0, nil, err
-	}
-	if trustedBlockHeight == 0 {
-		return 0, nil, fmt.Errorf("trusted block height cannot be zero")
-	}
-
-	trustedBlockHashStr, err := cmd.Flags().GetString(flags.FlagTrustedBlockHash)
-	if err != nil {
-		return 0, nil, err
-	}
-	if trustedBlockHashStr == "" {
-		return 0, nil, fmt.Errorf("trusted block hash cannot be empty")
-	}
-
-	trustedBlockHash, err := base64.StdEncoding.DecodeString(trustedBlockHashStr)
-	if err != nil {
-		return 0, nil, err
-	}
-
-	return trustedBlockHeight, trustedBlockHash, nil
-}
-
-// getOracleAccount gets an oracle account from mnemonic.
-// The account is equal to one that is registered as validator.
-// You can set account number and index optionally.
-// The default value is 0 for both account number and index
-func getOracleAccount(cmd *cobra.Command, mnemonic string) (*panacea.OracleAccount, error) {
-	accNum, err := cmd.Flags().GetUint32(flags.FlagAccNum)
-	if err != nil {
-		return &panacea.OracleAccount{}, err
-	}
-
-	index, err := cmd.Flags().GetUint32(flags.FlagIndex)
-	if err != nil {
-		return &panacea.OracleAccount{}, err
-	}
-
-	oracleAccount, err := panacea.NewOracleAccount(mnemonic, accNum, index)
-	if err != nil {
-		return &panacea.OracleAccount{}, err
-	}
-
-	return oracleAccount, nil
 }

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -1,19 +1,35 @@
 package service
 
 import (
+	"encoding/base64"
 	"fmt"
+	"github.com/medibloc/panacea-doracle/client/flags"
 	"github.com/medibloc/panacea-doracle/config"
 	"github.com/medibloc/panacea-doracle/panacea"
-	"github.com/medibloc/panacea-doracle/store"
+	"github.com/spf13/cobra"
 )
 
 type Service struct {
 	Conf          *config.Config
-	Store         store.Storage
+	OracleAccount *panacea.OracleAccount
+	TrustedHeight int64
+	TrustedHash   []byte
 	PanaceaClient panacea.GrpcClientI
 }
 
-func New(conf *config.Config) (*Service, error) {
+func New(cmd *cobra.Command, conf *config.Config) (*Service, error) {
+	// get trusted block information
+	height, hash, err := getTrustedBlockInfo(cmd)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get trusted block info: %w", err)
+	}
+
+	// get oracle account from mnemonic.
+	oracleAccount, err := getOracleAccount(cmd, conf.OracleMnemonic)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get oracle account from mnemonic: %w", err)
+	}
+
 	panaceaClient, err := panacea.NewGrpcClient(conf)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Panacea gRPC client: %w", err)
@@ -21,10 +37,62 @@ func New(conf *config.Config) (*Service, error) {
 
 	return &Service{
 		Conf:          conf,
+		OracleAccount: oracleAccount,
+		TrustedHeight: height,
+		TrustedHash:   hash,
 		PanaceaClient: panaceaClient,
 	}, nil
 }
 
 func (svc *Service) Close() {
-	svc.PanaceaClient.Close()
+	_ = svc.PanaceaClient.Close()
+}
+
+// getTrustedBlockInfo gets trusted block height and hash from cmd flags
+func getTrustedBlockInfo(cmd *cobra.Command) (int64, []byte, error) {
+	trustedBlockHeight, err := cmd.Flags().GetInt64(flags.FlagTrustedBlockHeight)
+	if err != nil {
+		return 0, nil, err
+	}
+	if trustedBlockHeight == 0 {
+		return 0, nil, fmt.Errorf("trusted block height cannot be zero")
+	}
+
+	trustedBlockHashStr, err := cmd.Flags().GetString(flags.FlagTrustedBlockHash)
+	if err != nil {
+		return 0, nil, err
+	}
+	if trustedBlockHashStr == "" {
+		return 0, nil, fmt.Errorf("trusted block hash cannot be empty")
+	}
+
+	trustedBlockHash, err := base64.StdEncoding.DecodeString(trustedBlockHashStr)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	return trustedBlockHeight, trustedBlockHash, nil
+}
+
+// getOracleAccount gets an oracle account from mnemonic.
+// The account is equal to one that is registered as validator.
+// You can set account number and index optionally.
+// The default value is 0 for both account number and index
+func getOracleAccount(cmd *cobra.Command, mnemonic string) (*panacea.OracleAccount, error) {
+	accNum, err := cmd.Flags().GetUint32(flags.FlagAccNum)
+	if err != nil {
+		return &panacea.OracleAccount{}, err
+	}
+
+	index, err := cmd.Flags().GetUint32(flags.FlagIndex)
+	if err != nil {
+		return &panacea.OracleAccount{}, err
+	}
+
+	oracleAccount, err := panacea.NewOracleAccount(mnemonic, accNum, index)
+	if err != nil {
+		return &panacea.OracleAccount{}, err
+	}
+
+	return oracleAccount, nil
 }

--- a/sgx/seal.go
+++ b/sgx/seal.go
@@ -22,3 +22,17 @@ func SealToFile(data []byte, filePath string) error {
 
 	return nil
 }
+
+func UnsealFromFile(filePath string) ([]byte, error) {
+	sealed, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s: %w", filePath, err)
+	}
+
+	key, err := ecrypto.Unseal(sealed, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unseal oracle key: %w", err)
+	}
+
+	return key, nil
+}

--- a/types/consts.go
+++ b/types/consts.go
@@ -1,6 +1,8 @@
 package types
 
 var (
+	DefaultDoracleDir = ".doracle"
+
 	DefaultOraclePrivKeyName = "oracle_priv_key.sealed"
 	DefaultNodePrivKeyName   = "node_priv_key.sealed"
 


### PR DESCRIPTION
Close #7 

Some refactoring has been done including graceful shutdown and operation for each situation.

First, check if there is an existing node key.

If exists, continue the oracle registration process with the existing node key.
Or create a new one and request oracle registration to Panacea (done in #11).

When the node key exists, some checks would be done as below. 
- check if the existing node public key is equal to the one used in `OracleRegistration` in Panacea
- check the status of `OracleRegistration` (handling for each situation: `VotingPeriod`, `Passed`, `Rejected`)