### PR TITLE
chore: use tx response raw log instead of logs

### DIFF
--- a/cmd/doracled/cmd/register_oracle.go
+++ b/cmd/doracled/cmd/register_oracle.go
@@ -82,7 +82,7 @@ func registerOracleCmd() *cobra.Command {
 			}
 
 			if resp.TxResponse.Code != 0 {
-				return fmt.Errorf("register oracle transaction failed: %v", resp.TxResponse.Logs)
+				return fmt.Errorf("register oracle transaction failed: %v", resp.TxResponse.RawLog)
 			}
 
 			log.Info("register-oracle transaction succeed")

--- a/config/config.go
+++ b/config/config.go
@@ -19,9 +19,9 @@ type PanaceaConfig struct {
 	GRPCAddr         string `mapstructure:"grpc-addr"`
 	DefaultGasLimit  uint64 `mapstructure:"default-gas-limit"`
 	DefaultFeeAmount string `mapstructure:"default-fee-amount"`
-	PrimaryAddr   string `mapstructure:"primary-addr"`
-	WitnessesAddr string `mapstructure:"witnesses-addr"`
-	RpcAddr       string `mapstructure:"rpc-addr"`
+	PrimaryAddr      string `mapstructure:"primary-addr"`
+	WitnessesAddr    string `mapstructure:"witnesses-addr"`
+	RpcAddr          string `mapstructure:"rpc-addr"`
 }
 
 func DefaultConfig() *Config {
@@ -34,11 +34,11 @@ func DefaultConfig() *Config {
 		Panacea: PanaceaConfig{
 			ChainID:          "panacea-3",
 			GRPCAddr:         "https://grpc.gopanacea.org:443",
-			DefaultGasLimit:  200000,
-			DefaultFeeAmount: "1000000umed",
-			PrimaryAddr:   "https://rpc.gopanacea.org:443",
-			WitnessesAddr: "https://rpc.gopanacea.org:443",
-			RpcAddr:       "https://rpc.gopanacea.org:443",
+			DefaultGasLimit:  300000,
+			DefaultFeeAmount: "1500000umed",
+			PrimaryAddr:      "https://rpc.gopanacea.org:443",
+			WitnessesAddr:    "https://rpc.gopanacea.org:443",
+			RpcAddr:          "https://rpc.gopanacea.org:443",
 		},
 	}
 }


### PR DESCRIPTION
When Tx fails, there is no info in `TxResponse.Logs`. Instead, changed to `TxResponse.RawLog` which has detailed info of transaction.

FYI) I also increased the default gas limit and fee because with the previous values, tx fails with an error of `out of gas`.