### PR TITLE
refactor: change uniqueID encoding from base64 to hex

### DIFF
--- a/cmd/doracled/cmd/get_oracle_key.go
+++ b/cmd/doracled/cmd/get_oracle_key.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"bytes"
-	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"github.com/btcsuite/btcd/btcec"
@@ -49,7 +49,7 @@ This oracle private key can also be accessed in SGX-enabled environment using th
 		if err != nil {
 			return fmt.Errorf("failed to get self enclave info: %w", err)
 		}
-		uniqueID := base64.StdEncoding.EncodeToString(selfEnclaveInfo.UniqueID)
+		uniqueID := hex.EncodeToString(selfEnclaveInfo.UniqueID)
 
 		// get oracle account from mnemonic.
 		oracleAccount, err := getOracleAccount(cmd, conf.OracleMnemonic)

--- a/cmd/doracled/cmd/register_oracle.go
+++ b/cmd/doracled/cmd/register_oracle.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -57,10 +58,10 @@ func registerOracleCmd() *cobra.Command {
 			}
 
 			report, _ := enclave.VerifyRemoteReport(nodePubKeyRemoteReport)
-			uniqueIDStr := base64.StdEncoding.EncodeToString(report.UniqueID)
+			uniqueID := hex.EncodeToString(report.UniqueID)
 
 			// sign and broadcast to Panacea
-			msgRegisterOracle := oracletypes.NewMsgRegisterOracle(uniqueIDStr, oracleAccount.GetAddress(), nodePubKey, nodePubKeyRemoteReport, trustedBlockInfo.TrustedBlockHeight, trustedBlockInfo.TrustedBlockHash)
+			msgRegisterOracle := oracletypes.NewMsgRegisterOracle(uniqueID, oracleAccount.GetAddress(), nodePubKey, nodePubKeyRemoteReport, trustedBlockInfo.TrustedBlockHeight, trustedBlockInfo.TrustedBlockHash)
 
 			cli, txBuilder, err := generateGrpcClientAndTxBuilder(conf)
 			if err != nil {

--- a/service/service.go
+++ b/service/service.go
@@ -1,7 +1,7 @@
 package service
 
 import (
-	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/medibloc/panacea-doracle/config"
@@ -49,7 +49,7 @@ func New(conf *config.Config) (*Service, error) {
 	return &Service{
 		Conf:          conf,
 		OraclePrivKey: oraclePrivKey,
-		UniqueID:      base64.StdEncoding.EncodeToString(selfEnclaveInfo.UniqueID),
+		UniqueID:      hex.EncodeToString(selfEnclaveInfo.UniqueID),
 		GrpcClient:    grpcClient.(*panacea.GrpcClient),
 	}, nil
 }


### PR DESCRIPTION
Refactoring of changing encoding of `uniqueID` from base64 to hex

Ego uses hex encoding for uniqueID. On the other hand, we used base64 encoding uniqueID.
Thus, it was difficult to use the hex-encoded uniqueID, which can be obtained from the `ego uniqueid <executable>` cmd, for interaction with Panacea because different encoded uniqueID was used to store data (e.g. oracle registration).

By using the same encoding scheme, user can utilize the encoded uniqueID obtained from `ego uniqueid` cmd as it is.