### PR TITLE
feat: add LoadQueryClient function

### DIFF
--- a/panacea/query_client.go
+++ b/panacea/query_client.go
@@ -67,7 +67,7 @@ func newQueryClient(ctx context.Context, config *config.Config, info *TrustedBlo
 		return nil, err
 	}
 
-	pv, err := tmhttp.New(chainID, config.Panacea.PrimaryAddr)
+	pv, err := tmhttp.New(chainID, config.Panacea.LightClientPrimaryAddr)
 	if err != nil {
 		return nil, err
 	}

--- a/panacea/query_client_test.go
+++ b/panacea/query_client_test.go
@@ -46,6 +46,9 @@ func TestGetAccount(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, mediblocLimitedAddress, address)
+
+	err = queryClient.Close()
+	require.NoError(t, err)
 }
 
 func TestMultiGetAddress(t *testing.T) {
@@ -115,6 +118,9 @@ func TestMultiGetAddress(t *testing.T) {
 	}()
 	wg.Wait()
 
+	err = queryClient.Close()
+	require.NoError(t, err)
+
 }
 
 func TestLoadQueryClient(t *testing.T) {
@@ -146,10 +152,13 @@ func TestLoadQueryClient(t *testing.T) {
 	err = queryClient.Close()
 	require.NoError(t, err)
 
-	queryClient2, err := panacea.LoadQueryClient(ctx, conf)
+	queryClient, err = panacea.LoadQueryClient(ctx, conf)
 	require.NoError(t, err)
 
-	_, err = queryClient2.LightClient.LastTrustedHeight()
+	_, err = queryClient.LightClient.LastTrustedHeight()
+	require.NoError(t, err)
+
+	err = queryClient.Close()
 	require.NoError(t, err)
 
 }

--- a/panacea/query_client_test.go
+++ b/panacea/query_client_test.go
@@ -1,204 +1,155 @@
 package panacea_test
 
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"github.com/cosmos/cosmos-sdk/types/bech32"
+	"github.com/medibloc/panacea-doracle/config"
+	"github.com/medibloc/panacea-doracle/panacea"
+	"github.com/stretchr/testify/require"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
 // All the tests can only work in sgx environment, so the tests are commented out.
 
 // Test for GetAccount function.
-//func TestGetAccount(t *testing.T) {
-//
-//	hash, err := hex.DecodeString("3531F0F323110AA7831775417B9211348E16A29A07FBFD46018936625E4E5492")
-//	require.NoError(t, err)
-//	ctx := context.Background()
-//
-//	trustedBlockinfo := panacea.TrustedBlockInfo{
-//		TrustedBlockHeight: 99,
-//		TrustedBlockHash:   hash,
-//	}
-//	userHomeDir, err := os.UserHomeDir()
-//	require.NoError(t, err)
-//
-//	homeDir := filepath.Join(userHomeDir, ".doracle")
-//	conf, err := config.ReadConfigTOML(filepath.Join(homeDir, "config.toml"))
-//	require.NoError(t, err)
-//
-//	queryClient, err := panacea.NewQueryClient(ctx, conf, trustedBlockinfo)
-//
-//	require.NoError(t, err)
-//
-//	mediblocLimitedAddress := "panacea1ewugvs354xput6xydl5cd5tvkzcuymkejekwk3"
-//	accAddr, err := queryClient.GetAccount(mediblocLimitedAddress)
-//	require.NoError(t, err)
-//
-//	address, err := bech32.ConvertAndEncode("panacea", accAddr.GetPubKey().Address().Bytes())
-//	require.NoError(t, err)
-//
-//	require.Equal(t, mediblocLimitedAddress, address)
-//}
+func TestGetAccount(t *testing.T) {
 
-//func TestMultiGetAddress(t *testing.T) {
-//
-//	hash, err := hex.DecodeString("3531F0F323110AA7831775417B9211348E16A29A07FBFD46018936625E4E5492")
-//	require.NoError(t, err)
-//	ctx := context.Background()
-//
-//	trustedBlockinfo := panacea.TrustedBlockInfo{
-//		TrustedBlockHeight: 99,
-//		TrustedBlockHash:   hash,
-//	}
-//	userHomeDir, err := os.UserHomeDir()
-//	require.NoError(t, err)
-//
-//	homeDir := filepath.Join(userHomeDir, ".doracle")
-//	conf, err := config.ReadConfigTOML(filepath.Join(homeDir, "config.toml"))
-//	require.NoError(t, err)
-//
-//	queryClient, err := panacea.NewQueryClient(ctx, conf, trustedBlockinfo)
-//
-//	require.NoError(t, err)
-//
-//	mediblocLimitedAddress := "panacea1ewugvs354xput6xydl5cd5tvkzcuymkejekwk3"
-//
-//	var wg sync.WaitGroup
-//	wg.Add(5)
-//
-//	fmt.Println("query 1 send")
-//	go func() {
-//		_, err := queryClient.GetAccount(mediblocLimitedAddress)
-//		require.NoError(t, err)
-//		wg.Done()
-//		fmt.Println("query 1 receive")
-//	}()
-//
-//	fmt.Println("query 2 send")
-//	go func() {
-//		_, err := queryClient.GetAccount(mediblocLimitedAddress)
-//		require.NoError(t, err)
-//		wg.Done()
-//		fmt.Println("query 2 receive")
-//	}()
-//
-//	fmt.Println("query 3 send")
-//	go func() {
-//		_, err := queryClient.GetAccount(mediblocLimitedAddress)
-//		require.NoError(t, err)
-//		wg.Done()
-//		fmt.Println("query 3 receive")
-//	}()
-//
-//	fmt.Println("query 4 send")
-//	go func() {
-//		_, err := queryClient.GetAccount(mediblocLimitedAddress)
-//		require.NoError(t, err)
-//		wg.Done()
-//		fmt.Println("query 4 receive")
-//	}()
-//
-//	fmt.Println("query 5 send")
-//	go func() {
-//		_, err := queryClient.GetAccount(mediblocLimitedAddress)
-//		require.NoError(t, err)
-//		wg.Done()
-//		fmt.Println("query 5 receive")
-//	}()
-//	wg.Wait()
-//
-//}
+	hash, err := hex.DecodeString("3531F0F323110AA7831775417B9211348E16A29A07FBFD46018936625E4E5492")
+	require.NoError(t, err)
+	ctx := context.Background()
 
-//func TestLightClientConnection(t *testing.T) {
-//	hash, err := hex.DecodeString("3531F0F323110AA7831775417B9211348E16A29A07FBFD46018936625E4E5492")
-//	require.NoError(t, err)
-//	ctx := context.Background()
-//
-//	userHomeDir, err := os.UserHomeDir()
-//	require.NoError(t, err)
-//
-//	homeDir := filepath.Join(userHomeDir, ".doracle")
-//	conf, err := config.ReadConfigTOML(filepath.Join(homeDir, "config.toml"))
-//	require.NoError(t, err)
-//
-//	trustedBlockinfo := panacea.TrustedBlockInfo{
-//		TrustedBlockHeight: 99,
-//		TrustedBlockHash:   hash,
-//	}
-//
-//	queryClient, err := panacea.NewQueryClient(ctx, conf, trustedBlockinfo)
-//	require.NoError(t, err)
-//
-//	_, err = queryClient.LightClient.LastTrustedHeight()
-//	require.NoError(t, err)
-//
-//	_, err = panacea.NewQueryClient(ctx, conf, trustedBlockinfo)
-//	require.Error(t, err)
-//
-//	err = queryClient.Close()
-//	require.NoError(t, err)
-//
-//	queryClient2, err := panacea.NewQueryClient(ctx, conf, trustedBlockinfo)
-//	require.NoError(t, err)
-//
-//	_, err = queryClient2.LightClient.LastTrustedHeight()
-//	require.NoError(t, err)
-//
-//}
+	trustedBlockinfo := panacea.TrustedBlockInfo{
+		TrustedBlockHeight: 99,
+		TrustedBlockHash:   hash,
+	}
+	userHomeDir, err := os.UserHomeDir()
+	require.NoError(t, err)
 
-// Test for GetBalance function.
-// The test fails due to a version problem of the current panacea mainNet.
-//func TestGetBalance(t *testing.T) {
-//	hash, err := hex.DecodeString("3531F0F323110AA7831775417B9211348E16A29A07FBFD46018936625E4E5492")
-//	require.NoError(t, err)
-//	ctx := context.Background()
-//
-//	trustedBlockinfo := panacea.TrustedBlockInfo{
-//		TrustedBlockHeight: 99,
-//		TrustedBlockHash:   hash,
-//	}
-//
-//	userHomeDir, err := os.UserHomeDir()
-//	if err != nil {
-//		panic(err)
-//	}
-//	homeDir := filepath.Join(userHomeDir, ".doracle")
-//	conf, err := config.ReadConfigTOML(filepath.Join(homeDir, "config.toml"))
-//	require.NoError(t, err)
-//
-//	queryClient, err := panacea.NewQueryClient(ctx, conf, trustedBlockinfo)
-//
-//	require.NoError(t, err)
-//
-//	mediblocLimitedAddress := "panacea1ewugvs354xput6xydl5cd5tvkzcuymkejekwk3"
-//	balance, err := queryClient.GetBalance(mediblocLimitedAddress)
-//	require.NoError(t, err)
-//
-//	fmt.Println("balance: ", balance.String())
-//
-//}
+	homeDir := filepath.Join(userHomeDir, ".doracle")
+	conf, err := config.ReadConfigTOML(filepath.Join(homeDir, "config.toml"))
+	require.NoError(t, err)
 
-// Test for GetTopic function.
-// It is commented out because it is a test in a local environment.
-//func TestGetTopicLocal(t *testing.T) {
-//	hash, err := hex.DecodeString("226F43C4D9962545285E736B64004A83528E36281DB8CC4B7A1C60FECA003832")
-//	require.NoError(t, err)
-//	ctx := context.Background()
-//
-//	trustedBlockinfo := panacea.TrustedBlockInfo{
-//		TrustedBlockHeight: 99,
-//		TrustedBlockHash:   hash,
-//	}
-//
-//	userHomeDir, err := os.UserHomeDir()
-//	if err != nil {
-//		panic(err)
-//	}
-//	homeDir := filepath.Join(userHomeDir, ".doracle")
-//	conf, err := config.ReadConfigTOML(filepath.Join(homeDir, "config.toml"))
-//	require.NoError(t, err)
-//
-//	queryClient, err := panacea.NewQueryClient(ctx, conf, trustedBlockinfo)
-//
-//	require.NoError(t, err)
-//
-//	mediblocLimitedAddress := "panacea1crvw2ysrlrtzyk0m2u9m0eq0jrmpf6exxx7sex"
-//	topic, err := queryClient.GetTopic(mediblocLimitedAddress, "test")
-//	require.NoError(t, err)
-//
-//	fmt.Println("topic: ", topic.String())
-//}
+	queryClient, err := panacea.NewQueryClient(ctx, conf, trustedBlockinfo)
+
+	require.NoError(t, err)
+
+	mediblocLimitedAddress := "panacea1ewugvs354xput6xydl5cd5tvkzcuymkejekwk3"
+	accAddr, err := queryClient.GetAccount(mediblocLimitedAddress)
+	require.NoError(t, err)
+
+	address, err := bech32.ConvertAndEncode("panacea", accAddr.GetPubKey().Address().Bytes())
+	require.NoError(t, err)
+
+	require.Equal(t, mediblocLimitedAddress, address)
+}
+
+func TestMultiGetAddress(t *testing.T) {
+
+	hash, err := hex.DecodeString("3531F0F323110AA7831775417B9211348E16A29A07FBFD46018936625E4E5492")
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	trustedBlockinfo := panacea.TrustedBlockInfo{
+		TrustedBlockHeight: 99,
+		TrustedBlockHash:   hash,
+	}
+	userHomeDir, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	homeDir := filepath.Join(userHomeDir, ".doracle")
+	conf, err := config.ReadConfigTOML(filepath.Join(homeDir, "config.toml"))
+	require.NoError(t, err)
+
+	queryClient, err := panacea.NewQueryClient(ctx, conf, trustedBlockinfo)
+
+	require.NoError(t, err)
+
+	mediblocLimitedAddress := "panacea1ewugvs354xput6xydl5cd5tvkzcuymkejekwk3"
+
+	var wg sync.WaitGroup
+	wg.Add(5)
+
+	fmt.Println("query 1 send")
+	go func() {
+		_, err := queryClient.GetAccount(mediblocLimitedAddress)
+		require.NoError(t, err)
+		wg.Done()
+		fmt.Println("query 1 receive")
+	}()
+
+	fmt.Println("query 2 send")
+	go func() {
+		_, err := queryClient.GetAccount(mediblocLimitedAddress)
+		require.NoError(t, err)
+		wg.Done()
+		fmt.Println("query 2 receive")
+	}()
+
+	fmt.Println("query 3 send")
+	go func() {
+		_, err := queryClient.GetAccount(mediblocLimitedAddress)
+		require.NoError(t, err)
+		wg.Done()
+		fmt.Println("query 3 receive")
+	}()
+
+	fmt.Println("query 4 send")
+	go func() {
+		_, err := queryClient.GetAccount(mediblocLimitedAddress)
+		require.NoError(t, err)
+		wg.Done()
+		fmt.Println("query 4 receive")
+	}()
+
+	fmt.Println("query 5 send")
+	go func() {
+		_, err := queryClient.GetAccount(mediblocLimitedAddress)
+		require.NoError(t, err)
+		wg.Done()
+		fmt.Println("query 5 receive")
+	}()
+	wg.Wait()
+
+}
+
+func TestLoadQueryClient(t *testing.T) {
+	hash, err := hex.DecodeString("3531F0F323110AA7831775417B9211348E16A29A07FBFD46018936625E4E5492")
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	userHomeDir, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	homeDir := filepath.Join(userHomeDir, ".doracle")
+	conf, err := config.ReadConfigTOML(filepath.Join(homeDir, "config.toml"))
+	require.NoError(t, err)
+
+	trustedBlockinfo := panacea.TrustedBlockInfo{
+		TrustedBlockHeight: 99,
+		TrustedBlockHash:   hash,
+	}
+
+	queryClient, err := panacea.NewQueryClient(ctx, conf, trustedBlockinfo)
+	require.NoError(t, err)
+
+	_, err = queryClient.LightClient.LastTrustedHeight()
+	require.NoError(t, err)
+
+	_, err = panacea.NewQueryClient(ctx, conf, trustedBlockinfo)
+	require.Error(t, err)
+
+	err = queryClient.Close()
+	require.NoError(t, err)
+
+	queryClient2, err := panacea.LoadQueryClient(ctx, conf)
+	require.NoError(t, err)
+
+	_, err = queryClient2.LightClient.LastTrustedHeight()
+	require.NoError(t, err)
+
+}


### PR DESCRIPTION
Add `LoadQueryClient` function that can get `queryClient` from trustedStore.

Since the light block that has already been saved is used (by `NewQueryClient`), there is no need to use trusted block info as a parameter.