### PR TITLE
refactor: reorganize panacea configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,8 @@ For that, the public key and its remote report are required.
 
 ```json
 {
-  "public_key_base_64" : "<base64-encoded-public-key>",
-  "remote_report_base_64": "<base64-encoded-remote-report>"
+  "public_key_base64" : "<base64-encoded-public-key>",
+  "remote_report_base64": "<base64-encoded-remote-report>"
 }
 ```
 

--- a/cmd/doracled/cmd/gen_oracle_key.go
+++ b/cmd/doracled/cmd/gen_oracle_key.go
@@ -20,8 +20,8 @@ import (
 
 // OraclePubKeyInfo is a struct to store oracle public key and its remote report
 type OraclePubKeyInfo struct {
-	PublicKeyBase64    string `json:"public_key_base_64"`
-	RemoteReportBase64 string `json:"remote_report_base_64"`
+	PublicKeyBase64    string `json:"public_key_base64"`
+	RemoteReportBase64 string `json:"remote_report_base64"`
 }
 
 var genOracleKeyCmd = &cobra.Command{

--- a/config/config.go
+++ b/config/config.go
@@ -16,14 +16,13 @@ type BaseConfig struct {
 }
 
 type PanaceaConfig struct {
-	GRPCAddr         string `mapstructure:"grpc-addr"`
-	WSAddr           string `mapstructure:"websocket-addr"`
-	ChainID          string `mapstructure:"chain-id"`
-	DefaultGasLimit  uint64 `mapstructure:"default-gas-limit"`
-	DefaultFeeAmount string `mapstructure:"default-fee-amount"`
-	PrimaryAddr      string `mapstructure:"primary-addr"`
-	WitnessesAddr    string `mapstructure:"witnesses-addr"`
-	RpcAddr          string `mapstructure:"rpc-addr"`
+	GRPCAddr                string `mapstructure:"grpc-addr"`
+	RPCAddr                 string `mapstructure:"rpc-addr"`
+	ChainID                 string `mapstructure:"chain-id"`
+	DefaultGasLimit         uint64 `mapstructure:"default-gas-limit"`
+	DefaultFeeAmount        string `mapstructure:"default-fee-amount"`
+	LightClientPrimaryAddr  string `mapstructure:"light-client-primary-addr"`
+	LightClientWitnessAddrs []string `mapstructure:"light-client-witness-addrs"`
 }
 
 func DefaultConfig() *Config {
@@ -34,14 +33,13 @@ func DefaultConfig() *Config {
 			ListenAddr:     "127.0.0.1:8080",
 		},
 		Panacea: PanaceaConfig{
-			GRPCAddr:         "127.0.0.1:9090",
-			WSAddr:           "tcp://127.0.0.1:26657",
-			ChainID:          "panacea-3",
-			DefaultGasLimit:  300000,
-			DefaultFeeAmount: "1500000umed",
-			PrimaryAddr:      "https://rpc.gopanacea.org:443",
-			WitnessesAddr:    "https://rpc.gopanacea.org:443",
-			RpcAddr:          "https://rpc.gopanacea.org:443",
+			GRPCAddr:                "127.0.0.1:9090",
+			RPCAddr:                 "tcp://127.0.0.1:26657",
+			ChainID:                 "panacea-3",
+			DefaultGasLimit:         300000,
+			DefaultFeeAmount:        "1500000umed",
+			LightClientPrimaryAddr:  "tcp://127.0.0.1:26657",
+			LightClientWitnessAddrs: []string{"tcp://127.0.0.1:26657"},
 		},
 	}
 }

--- a/config/toml.go
+++ b/config/toml.go
@@ -35,7 +35,9 @@ rpc-addr = "{{ .Panacea.RPCAddr }}"
 default-gas-limit = "{{ .Panacea.DefaultGasLimit }}"
 default-fee-amount = "{{ .Panacea.DefaultFeeAmount }}"
 
+# A primary RPC address for light client verification
 light-client-primary-addr = "{{ .Panacea.LightClientPrimaryAddr }}"
+# Witness addresses (comma-separated) for light client verification
 light-client-witness-addrs= "{{ StringsJoin .Panacea.LightClientWitnessAddrs "," }}"
 `
 

--- a/config/toml.go
+++ b/config/toml.go
@@ -31,20 +31,21 @@ listen_addr = "{{ .BaseConfig.ListenAddr }}"
 
 chain-id = "{{ .Panacea.ChainID }}"
 grpc-addr = "{{ .Panacea.GRPCAddr }}"
-websocket-addr = "{{ .Panacea.WSAddr }}"
+rpc-addr = "{{ .Panacea.RPCAddr }}"
 default-gas-limit = "{{ .Panacea.DefaultGasLimit }}"
 default-fee-amount = "{{ .Panacea.DefaultFeeAmount }}"
 
-primary-addr = "{{ .Panacea.PrimaryAddr }}"
-witnesses-addr= "{{ .Panacea.WitnessesAddr }}"
-rpc-addr= "{{ .Panacea.RpcAddr }}"
+light-client-primary-addr = "{{ .Panacea.LightClientPrimaryAddr }}"
+light-client-witness-addrs= "{{ StringsJoin .Panacea.LightClientWitnessAddrs "," }}"
 `
 
 var configTemplate *template.Template
 
 // init is run automatically when the package is loaded.
 func init() {
-	tmpl := template.New("configFileTemplate")
+	tmpl := template.New("configFileTemplate").Funcs(template.FuncMap{
+		"StringsJoin": strings.Join,
+	})
 
 	var err error
 	if configTemplate, err = tmpl.Parse(DefaultConfigTemplate); err != nil {

--- a/event/subscriber.go
+++ b/event/subscriber.go
@@ -15,7 +15,7 @@ type PanaceaSubscriber struct {
 
 // NewSubscriber generates a rpc http client with websocket address.
 func NewSubscriber(svc *service.Service) (*PanaceaSubscriber, error) {
-	client, err := rpchttp.New(svc.Conf.Panacea.WSAddr, "/websocket")
+	client, err := rpchttp.New(svc.Conf.Panacea.RPCAddr, "/websocket")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- We don't need to have `websocket-addr` and `rpc-addr` together. Both are the same.
- I renamed the `witnesses-addr` to `witness-addrs`.
- I put a `light-client-` prefix to the `primary-addr` and `witness-addrs`.
  - with parsing `witness-addrs` immediately when unmarshalling the toml file.
- Also, I don't recommend to expose `*.gopanacea.org` addrs in our codebase.