### PR TITLE
refactor: do not use global vars and `init()` for query_client (light client)

### DIFF
--- a/cmd/doracled/cmd/init.go
+++ b/cmd/doracled/cmd/init.go
@@ -2,11 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/medibloc/panacea-doracle/config"
-	"github.com/medibloc/panacea-doracle/panacea"
-	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
+
+	"github.com/medibloc/panacea-doracle/config"
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -27,14 +27,16 @@ var initCmd = &cobra.Command{
 			return fmt.Errorf("failed to create config dir: %w", err)
 		}
 
-		if _, err := os.Stat(panacea.DbDir); os.IsNotExist(err) {
-			err = os.MkdirAll(panacea.DbDir, 0755)
+		defaultConfig := config.DefaultConfig()
+
+		if _, err := os.Stat(defaultConfig.DataDir); os.IsNotExist(err) {
+			err = os.MkdirAll(defaultConfig.DataDir, 0755)
 			if err != nil {
 				return fmt.Errorf("failed to create db dir: %w", err)
 			}
 		}
 
-		return config.WriteConfigTOML(getConfigPath(), config.DefaultConfig())
+		return config.WriteConfigTOML(getConfigPath(), defaultConfig)
 	},
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -13,15 +13,16 @@ type BaseConfig struct {
 	OracleMnemonic string `mapstructure:"oracle-mnemonic"`
 	ListenAddr     string `mapstructure:"listen_addr"`
 	Subscriber     string `mapstructure:"subscriber"`
+	DataDir        string `mapstructure:"data_dir"`
 }
 
 type PanaceaConfig struct {
-	GRPCAddr                string `mapstructure:"grpc-addr"`
-	RPCAddr                 string `mapstructure:"rpc-addr"`
-	ChainID                 string `mapstructure:"chain-id"`
-	DefaultGasLimit         uint64 `mapstructure:"default-gas-limit"`
-	DefaultFeeAmount        string `mapstructure:"default-fee-amount"`
-	LightClientPrimaryAddr  string `mapstructure:"light-client-primary-addr"`
+	GRPCAddr                string   `mapstructure:"grpc-addr"`
+	RPCAddr                 string   `mapstructure:"rpc-addr"`
+	ChainID                 string   `mapstructure:"chain-id"`
+	DefaultGasLimit         uint64   `mapstructure:"default-gas-limit"`
+	DefaultFeeAmount        string   `mapstructure:"default-fee-amount"`
+	LightClientPrimaryAddr  string   `mapstructure:"light-client-primary-addr"`
 	LightClientWitnessAddrs []string `mapstructure:"light-client-witness-addrs"`
 }
 
@@ -31,6 +32,7 @@ func DefaultConfig() *Config {
 			LogLevel:       "info",
 			OracleMnemonic: "",
 			ListenAddr:     "127.0.0.1:8080",
+			DataDir:        "data",
 		},
 		Panacea: PanaceaConfig{
 			GRPCAddr:                "127.0.0.1:9090",

--- a/config/toml.go
+++ b/config/toml.go
@@ -22,6 +22,7 @@ const DefaultConfigTemplate = `# This is a TOML config file.
 log-level = "{{ .BaseConfig.LogLevel }}"
 oracle-mnemonic = "{{ .BaseConfig.OracleMnemonic }}"
 listen_addr = "{{ .BaseConfig.ListenAddr }}"
+data_dir = "{{ .BaseConfig.DataDir }}"
 
 ###############################################################################
 ###                         Panacea Configuration                           ###

--- a/panacea/query_client.go
+++ b/panacea/query_client.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"sync"
 	"time"
 
@@ -30,8 +28,6 @@ import (
 	tmtypes "github.com/tendermint/tendermint/types"
 )
 
-var DbDir string
-
 const (
 	denom = "umed"
 )
@@ -47,14 +43,6 @@ type QueryClient struct {
 	interfaceRegistry codectypes.InterfaceRegistry
 	sgxLevelDB        *sgxdb.SgxLevelDB
 	mutex             *sync.Mutex
-}
-
-func init() {
-	userHomeDir, err := os.UserHomeDir()
-	if err != nil {
-		panic(err)
-	}
-	DbDir = filepath.Join(userHomeDir, ".doracle", "data")
 }
 
 // NewQueryClient set QueryClient with rpcClient & and returns, if successful,
@@ -86,7 +74,7 @@ func NewQueryClient(ctx context.Context, config *config.Config, info TrustedBloc
 		}
 		pvs = append(pvs, witness)
 	}
-	db, err := sgxdb.NewSgxLevelDB("light-client-db", DbDir)
+	db, err := sgxdb.NewSgxLevelDB("light-client", config.DataDir)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
for code safety and unit tests