### PR TITLE
refactor: manage the lifecycle of `Subscriber` along with the `Service`

### DIFF
--- a/cmd/doracled/cmd/start.go
+++ b/cmd/doracled/cmd/start.go
@@ -2,15 +2,15 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/medibloc/panacea-doracle/client/flags"
-	"github.com/medibloc/panacea-doracle/config"
-	"github.com/medibloc/panacea-doracle/event"
-	"github.com/medibloc/panacea-doracle/service"
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 	"os"
 	"os/signal"
 	"syscall"
+
+	"github.com/medibloc/panacea-doracle/client/flags"
+	"github.com/medibloc/panacea-doracle/config"
+	"github.com/medibloc/panacea-doracle/service"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 )
 
 func startCmd() *cobra.Command {
@@ -32,23 +32,11 @@ func startCmd() *cobra.Command {
 				return fmt.Errorf("failed to get oracle account: %w", err)
 			}
 
-			svc, err := service.New(conf)
+			svc, err := service.New(conf, oracleAccount)
 			if err != nil {
 				return fmt.Errorf("failed to create service: %w", err)
 			}
 			defer svc.Close()
-
-			svc.OracleAccount = oracleAccount
-
-			subscriber, err := event.NewSubscriber(svc)
-			if err != nil {
-				return err
-			}
-			defer subscriber.Close()
-
-			if err := subscriber.Run(event.RegisterOracleEvent{}); err != nil {
-				return fmt.Errorf("failed to subscribe events: %w", err)
-			}
 
 			sigChan := make(chan os.Signal, 1)
 

--- a/cmd/doracled/cmd/start.go
+++ b/cmd/doracled/cmd/start.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/medibloc/panacea-doracle/client/flags"
 	"github.com/medibloc/panacea-doracle/config"
+	"github.com/medibloc/panacea-doracle/event"
 	"github.com/medibloc/panacea-doracle/service"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -37,6 +38,13 @@ func startCmd() *cobra.Command {
 				return fmt.Errorf("failed to create service: %w", err)
 			}
 			defer svc.Close()
+
+			err = svc.StartSubscriptions(
+				event.NewRegisterOracleEvent(svc),
+			)
+			if err != nil {
+				return fmt.Errorf("failed to start event subscription: %w", err)
+			}
 
 			sigChan := make(chan os.Signal, 1)
 

--- a/event/event.go
+++ b/event/event.go
@@ -1,7 +1,6 @@
 package event
 
 import (
-	"github.com/medibloc/panacea-doracle/service"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 )
 
@@ -12,5 +11,5 @@ type Event interface {
 
 	GetEventAttributeValue() string
 
-	EventHandler(event ctypes.ResultEvent, svc *service.Service) error
+	EventHandler(event ctypes.ResultEvent) error
 }

--- a/service/service.go
+++ b/service/service.go
@@ -55,26 +55,18 @@ func New(conf *config.Config, oracleAccount *panacea.OracleAccount) (*Service, e
 		return nil, fmt.Errorf("failed to init subscriber: %w", err)
 	}
 
-	svc := &Service{
+	return &Service{
 		conf:          conf,
 		oracleAccount: oracleAccount,
 		oraclePrivKey: oraclePrivKey,
 		enclaveInfo:   selfEnclaveInfo,
 		grpcClient:    grpcClient.(*panacea.GrpcClient),
 		subscriber:    subscriber,
-	}
-
-	if err := svc.startSubscriptions(); err != nil {
-		return nil, fmt.Errorf("failed to start subscriptions: %w", err)
-	}
-
-	return svc, nil
+	}, nil
 }
 
-func (s *Service) startSubscriptions() error {
-	return s.subscriber.Run(
-		event.NewRegisterOracleEvent(s),
-	)
+func (s *Service) StartSubscriptions(events ...event.Event) error {
+	return s.subscriber.Run(events...)
 }
 
 func (s *Service) Close() error {

--- a/service/service.go
+++ b/service/service.go
@@ -22,9 +22,9 @@ type Service struct {
 	oraclePrivKey *btcec.PrivateKey
 	uniqueID      string
 
-	queryClient *panacea.QueryClient
-	grpcClient  *panacea.GrpcClient
-	subscriber  *event.PanaceaSubscriber
+	// queryClient *panacea.QueryClient //TODO: uncomment this
+	grpcClient *panacea.GrpcClient
+	subscriber *event.PanaceaSubscriber
 }
 
 func New(conf *config.Config, oracleAccount *panacea.OracleAccount) (*Service, error) {


### PR DESCRIPTION
Based on @inchori 's PR #32 

- For easy graceful shutdown, let's manage the lifecycle of `Subscriber` along with the `Service`, as all other components.
  - To avoid import cycle errors, I introduces the `reactor` interface for each event type.