### PR TITLE
refactor: use ProtoCodec provided by cosmos-sdk

### DIFF
--- a/panacea/query_client_test.go
+++ b/panacea/query_client_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/bech32"
 	"github.com/edgelesssys/ego/enclave"
 	oracletypes "github.com/medibloc/panacea-core/v2/x/oracle/types"
 	"github.com/medibloc/panacea-doracle/config"
@@ -18,36 +19,52 @@ import (
 )
 
 // Test for GetAccount function.
-//func TestGetAccount(t *testing.T) {
-//
-//	hash, err := hex.DecodeString("3531F0F323110AA7831775417B9211348E16A29A07FBFD46018936625E4E5492")
-//	require.NoError(t, err)
-//	ctx := context.Background()
-//
-//	trustedBlockinfo := panacea.TrustedBlockInfo{
-//		TrustedBlockHeight: 99,
-//		TrustedBlockHash:   hash,
-//	}
-//	userHomeDir, err := os.UserHomeDir()
-//	require.NoError(t, err)
-//
-//	homeDir := filepath.Join(userHomeDir, ".doracle")
-//	conf, err := config.ReadConfigTOML(filepath.Join(homeDir, "config.toml"))
-//	require.NoError(t, err)
-//
-//	queryClient, err := panacea.NewQueryClient(ctx, conf, trustedBlockinfo)
-//
-//	require.NoError(t, err)
-//
-//	mediblocLimitedAddress := "panacea1ewugvs354xput6xydl5cd5tvkzcuymkejekwk3"
-//	accAddr, err := queryClient.GetAccount(mediblocLimitedAddress)
-//	require.NoError(t, err)
-//
-//	address, err := bech32.ConvertAndEncode("panacea", accAddr.GetPubKey().Address().Bytes())
-//	require.NoError(t, err)
-//
-//	require.Equal(t, mediblocLimitedAddress, address)
-//}
+func TestGetAccount(t *testing.T) {
+
+	hash, err := hex.DecodeString("3531F0F323110AA7831775417B9211348E16A29A07FBFD46018936625E4E5492")
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	trustedBlockinfo := panacea.TrustedBlockInfo{
+		TrustedBlockHeight: 99,
+		TrustedBlockHash:   hash,
+	}
+
+	conf := &config.Config{
+		BaseConfig: config.BaseConfig{
+			LogLevel:          "",
+			OracleMnemonic:    "",
+			ListenAddr:        "",
+			Subscriber:        "",
+			DataDir:           "data",
+			OraclePrivKeyFile: "oracle_priv_key.sealed",
+			OraclePubKeyFile:  "oracle_pub_key.json",
+			NodePrivKeyFile:   "node_priv_key.sealed",
+		},
+		Panacea: config.PanaceaConfig{
+			GRPCAddr:                "https://grpc.gopanacea.org:443",
+			RPCAddr:                 "https://rpc.gopanacea.org:443",
+			ChainID:                 "panacea-3",
+			DefaultGasLimit:         200000,
+			DefaultFeeAmount:        "1000000umed",
+			LightClientPrimaryAddr:  "https://rpc.gopanacea.org:443",
+			LightClientWitnessAddrs: []string{"https://rpc.gopanacea.org:443"},
+		},
+	}
+
+	queryClient, err := panacea.NewQueryClient(ctx, conf, trustedBlockinfo)
+
+	require.NoError(t, err)
+
+	mediblocLimitedAddress := "panacea1ewugvs354xput6xydl5cd5tvkzcuymkejekwk3"
+	accAddr, err := queryClient.GetAccount(mediblocLimitedAddress)
+	require.NoError(t, err)
+
+	address, err := bech32.ConvertAndEncode("panacea", accAddr.GetPubKey().Address().Bytes())
+	require.NoError(t, err)
+
+	require.Equal(t, mediblocLimitedAddress, address)
+}
 
 //func TestMultiGetAddress(t *testing.T) {
 //


### PR DESCRIPTION
Based on @audtlr24 's PR.  #40 
* I made the code more concise by using `ProtoCodec` provided by cosmos-sdk