### PR TITLE
fix: do not call `RpcClient.OnStop()` in the `QueryClient`

### DIFF
--- a/panacea/query_client.go
+++ b/panacea/query_client.go
@@ -250,14 +250,7 @@ func (q QueryClient) GetStoreData(ctx context.Context, storeKey string, key []by
 }
 
 func (q QueryClient) Close() error {
-	err := q.sgxLevelDB.Close()
-	if err != nil {
-		return err
-	}
-
-	q.RpcClient.OnStop()
-
-	return nil
+	return q.sgxLevelDB.Close()
 }
 
 // Below are examples of query function that use GetStoreData function to verify queried result.


### PR DESCRIPTION
As the `QueryClient` doesn't call [RpcClient.Start()](https://github.com/tendermint/tendermint/blob/2f231ceb952a2426cf3c0abaf0b455aadd11e5b2/libs/service/service.go#L130) which starts subscriptions through websocket, we don't need to call [RpcClient.Stop()](https://github.com/tendermint/tendermint/blob/2f231ceb952a2426cf3c0abaf0b455aadd11e5b2/libs/service/service.go#L159). 
(Please note that you created the `RpcClient` using `rpchttp.New(config.Panacea.RPCAddr, "/websocket")`, but it doesn't start subscriptions through websocket. The subscriptions are started only after you call `RpcClient.Start()`.)

Basically, the `RpcClient` is just a HTTP client (for JSONRPC) which doesn't establish a persistent TCP connection with a server. That's why the `RpcClient` doesn't have a `Close()` function.

The `RpcClient.Stop()` should be called only if you called `RpcClient.Start()` before. Also, please don't forget to call `RpcClient.Stop()` instead of `RpcClient.OnStop()` (which is something like a 'stop handler' that is called by `RpcClient.Stop()`).