### PR TITLE
refactor: unexport private members in the `QueryClient`

### DIFF
--- a/panacea/query_client.go
+++ b/panacea/query_client.go
@@ -250,14 +250,7 @@ func (q QueryClient) GetStoreData(ctx context.Context, storeKey string, key []by
 }
 
 func (q QueryClient) Close() error {
-	err := q.sgxLevelDB.Close()
-	if err != nil {
-		return err
-	}
-
-	q.RpcClient.OnStop()
-
-	return nil
+	return q.sgxLevelDB.Close()
 }
 
 // Below are examples of query function that use GetStoreData function to verify queried result.

--- a/panacea/query_client.go
+++ b/panacea/query_client.go
@@ -39,8 +39,8 @@ type TrustedBlockInfo struct {
 }
 
 type QueryClient struct {
-	RpcClient         *rpchttp.HTTP
-	LightClient       *light.Client
+	rpcClient         *rpchttp.HTTP
+	lightClient       *light.Client
 	interfaceRegistry codectypes.InterfaceRegistry
 	sgxLevelDB        *sgxdb.SgxLevelDB
 	mutex             *sync.Mutex
@@ -57,8 +57,8 @@ func LoadQueryClient(ctx context.Context, config *config.Config) (*QueryClient, 
 }
 
 // newQueryClient creates a QueryClient.
-// If TrustedBlockInfo exists, a new LightClient is created based on this information,
-// and if TrustedBlockInfo is nil, a LightClient is created with information obtained from TrustedStore.
+// If TrustedBlockInfo exists, a new lightClient is created based on this information,
+// and if TrustedBlockInfo is nil, a lightClient is created with information obtained from TrustedStore.
 func newQueryClient(ctx context.Context, config *config.Config, info *TrustedBlockInfo) (*QueryClient, error) {
 	lcMutex := sync.Mutex{}
 	chainID := config.Panacea.ChainID
@@ -132,8 +132,8 @@ func newQueryClient(ctx context.Context, config *config.Config, info *TrustedBlo
 	}()
 
 	return &QueryClient{
-		RpcClient:         rpcClient,
-		LightClient:       lc,
+		rpcClient:         rpcClient,
+		lightClient:       lc,
 		interfaceRegistry: makeInterfaceRegistry(),
 		sgxLevelDB:        db,
 		mutex:             &lcMutex,
@@ -144,14 +144,14 @@ func (q QueryClient) safeUpdateLightClient(ctx context.Context) (*tmtypes.LightB
 	q.mutex.Lock()
 	defer q.mutex.Unlock()
 
-	return q.LightClient.Update(ctx, time.Now())
+	return q.lightClient.Update(ctx, time.Now())
 }
 
 func (q QueryClient) safeVerifyLightBlockAtHeight(ctx context.Context, height int64) (*tmtypes.LightBlock, error) {
 	q.mutex.Lock()
 	defer q.mutex.Unlock()
 
-	return q.LightClient.VerifyLightBlockAtHeight(ctx, height, time.Now())
+	return q.lightClient.VerifyLightBlockAtHeight(ctx, height, time.Now())
 }
 
 // refresh update light block, if the last light block has been updated more than trustPeriod * 2/3 ago.
@@ -192,7 +192,7 @@ func (q QueryClient) GetStoreData(ctx context.Context, storeKey string, key []by
 		return nil, err
 	}
 	if trustedBlock == nil {
-		queryHeight, err = q.LightClient.LastTrustedHeight()
+		queryHeight, err = q.lightClient.LastTrustedHeight()
 		if err != nil {
 			return nil, err
 		}
@@ -206,7 +206,7 @@ func (q QueryClient) GetStoreData(ctx context.Context, storeKey string, key []by
 		Height: queryHeight,
 	}
 	// query to kv store with proof option
-	result, err := q.RpcClient.ABCIQueryWithOptions(ctx, fmt.Sprintf("/store/%s/key", storeKey), key, option)
+	result, err := q.rpcClient.ABCIQueryWithOptions(ctx, fmt.Sprintf("/store/%s/key", storeKey), key, option)
 	if err != nil {
 		return nil, err
 	}

--- a/panacea/query_client_test.go
+++ b/panacea/query_client_test.go
@@ -1,17 +1,17 @@
-package panacea_test
+package panacea
 
 import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"github.com/cosmos/cosmos-sdk/types/bech32"
-	"github.com/medibloc/panacea-doracle/config"
-	"github.com/medibloc/panacea-doracle/panacea"
-	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"sync"
 	"testing"
+
+	"github.com/cosmos/cosmos-sdk/types/bech32"
+	"github.com/medibloc/panacea-doracle/config"
+	"github.com/stretchr/testify/require"
 )
 
 // All the tests can only work in sgx environment, so the tests are commented out.
@@ -23,7 +23,7 @@ func TestGetAccount(t *testing.T) {
 	require.NoError(t, err)
 	ctx := context.Background()
 
-	trustedBlockinfo := panacea.TrustedBlockInfo{
+	trustedBlockinfo := TrustedBlockInfo{
 		TrustedBlockHeight: 99,
 		TrustedBlockHash:   hash,
 	}
@@ -34,7 +34,7 @@ func TestGetAccount(t *testing.T) {
 	conf, err := config.ReadConfigTOML(filepath.Join(homeDir, "config.toml"))
 	require.NoError(t, err)
 
-	queryClient, err := panacea.NewQueryClient(ctx, conf, trustedBlockinfo)
+	queryClient, err := NewQueryClient(ctx, conf, trustedBlockinfo)
 
 	require.NoError(t, err)
 
@@ -57,7 +57,7 @@ func TestMultiGetAddress(t *testing.T) {
 	require.NoError(t, err)
 	ctx := context.Background()
 
-	trustedBlockinfo := panacea.TrustedBlockInfo{
+	trustedBlockinfo := TrustedBlockInfo{
 		TrustedBlockHeight: 99,
 		TrustedBlockHash:   hash,
 	}
@@ -68,7 +68,7 @@ func TestMultiGetAddress(t *testing.T) {
 	conf, err := config.ReadConfigTOML(filepath.Join(homeDir, "config.toml"))
 	require.NoError(t, err)
 
-	queryClient, err := panacea.NewQueryClient(ctx, conf, trustedBlockinfo)
+	queryClient, err := NewQueryClient(ctx, conf, trustedBlockinfo)
 
 	require.NoError(t, err)
 
@@ -135,27 +135,27 @@ func TestLoadQueryClient(t *testing.T) {
 	conf, err := config.ReadConfigTOML(filepath.Join(homeDir, "config.toml"))
 	require.NoError(t, err)
 
-	trustedBlockinfo := panacea.TrustedBlockInfo{
+	trustedBlockinfo := TrustedBlockInfo{
 		TrustedBlockHeight: 99,
 		TrustedBlockHash:   hash,
 	}
 
-	queryClient, err := panacea.NewQueryClient(ctx, conf, trustedBlockinfo)
+	queryClient, err := NewQueryClient(ctx, conf, trustedBlockinfo)
 	require.NoError(t, err)
 
-	_, err = queryClient.LightClient.LastTrustedHeight()
+	_, err = queryClient.lightClient.LastTrustedHeight()
 	require.NoError(t, err)
 
-	_, err = panacea.NewQueryClient(ctx, conf, trustedBlockinfo)
+	_, err = NewQueryClient(ctx, conf, trustedBlockinfo)
 	require.Error(t, err)
 
 	err = queryClient.Close()
 	require.NoError(t, err)
 
-	queryClient, err = panacea.LoadQueryClient(ctx, conf)
+	queryClient, err = LoadQueryClient(ctx, conf)
 	require.NoError(t, err)
 
-	_, err = queryClient.LightClient.LastTrustedHeight()
+	_, err = queryClient.lightClient.LastTrustedHeight()
 	require.NoError(t, err)
 
 	err = queryClient.Close()


### PR DESCRIPTION
Please try to not export members that are okay to be private.