### PR TITLE
feat: implement executing vote transaction after verify remote report

### DIFF
--- a/event/register_oracle_event.go
+++ b/event/register_oracle_event.go
@@ -1,9 +1,7 @@
 package event
 
 import (
-	"context"
 	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
@@ -31,6 +29,7 @@ type reactor interface {
 	OracleAcc() *panacea.OracleAccount
 	OraclePrivKey() *btcec.PrivateKey
 	Config() *config.Config
+	QueryClient() *panacea.QueryClient
 }
 
 func NewRegisterOracleEvent(r reactor) RegisterOracleEvent {
@@ -52,23 +51,13 @@ func (e RegisterOracleEvent) GetEventAttributeValue() string {
 func (e RegisterOracleEvent) EventHandler(event ctypes.ResultEvent) error {
 	addressValue := event.Events[types.EventTypeRegistrationVote+"."+types.AttributeKeyOracleAddress][0]
 
-	uniqueID := hex.EncodeToString(e.reactor.EnclaveInfo().UniqueID)
-	oracleRegistration, err := e.reactor.GRPCClient().GetOracleRegistration(addressValue, uniqueID)
+	uniqueID := e.reactor.EnclaveInfo().UniqueIDHex()
+	oracleRegistration, err := e.reactor.QueryClient().GetOracleRegistration(addressValue, uniqueID)
 	if err != nil {
 		return err
 	}
 
-	trustedBlockInfo := panacea.TrustedBlockInfo{
-		TrustedBlockHeight: oracleRegistration.TrustedBlockHeight,
-		TrustedBlockHash:   oracleRegistration.TrustedBlockHash,
-	}
-
-	queryClient, err := panacea.NewQueryClient(context.Background(), e.reactor.Config(), trustedBlockInfo)
-	if err != nil {
-		return err
-	}
-
-	txBuilder := panacea.NewTxBuilder(*queryClient)
+	txBuilder := panacea.NewTxBuilder(*e.reactor.QueryClient())
 
 	voteOption := verifyReportAndGetVoteOption(oracleRegistration, e)
 

--- a/event/register_oracle_event.go
+++ b/event/register_oracle_event.go
@@ -1,6 +1,7 @@
 package event
 
 import (
+	"crypto/sha256"
 	"encoding/hex"
 
 	"github.com/medibloc/panacea-core/v2/x/oracle/types"
@@ -46,7 +47,9 @@ func (e RegisterOracleEvent) EventHandler(event ctypes.ResultEvent) error {
 		return err
 	}
 
-	err = sgx.VerifyRemoteReport(oracleRegistration.NodePubKeyRemoteReport, oracleRegistration.NodePubKey, *e.reactor.EnclaveInfo())
+	nodePubKeyHash := sha256.Sum256(oracleRegistration.NodePubKey)
+
+	err = sgx.VerifyRemoteReport(oracleRegistration.NodePubKeyRemoteReport, nodePubKeyHash[:], *e.reactor.EnclaveInfo())
 	if err != nil {
 		return err
 	}

--- a/event/register_oracle_event.go
+++ b/event/register_oracle_event.go
@@ -82,7 +82,7 @@ func (e RegisterOracleEvent) EventHandler(event ctypes.ResultEvent) error {
 		return err
 	}
 
-	if err := broadCastTx(e.reactor.GRPCClient(), txBytes); err != nil {
+	if err := broadcastTx(e.reactor.GRPCClient(), txBytes); err != nil {
 		return err
 	}
 
@@ -94,7 +94,7 @@ func verifyReportAndGetVoteOption(oracleRegistration *types.OracleRegistration, 
 	nodePubKeyHash := sha256.Sum256(oracleRegistration.NodePubKey)
 
 	if err := sgx.VerifyRemoteReport(oracleRegistration.NodePubKeyRemoteReport, nodePubKeyHash[:], *e.reactor.EnclaveInfo()); err != nil {
-		log.Infof("failed to verification report. uniqueID(%s), address(%s), err(%v)", oracleRegistration.UniqueId, oracleRegistration.Address, err)
+		log.Warnf("failed to verification report. uniqueID(%s), address(%s), err(%v)", oracleRegistration.UniqueId, oracleRegistration.Address, err)
 		return types.VOTE_OPTION_NO
 	} else {
 		return types.VOTE_OPTION_YES
@@ -130,14 +130,14 @@ func makeOracleRegistrationVote(uniqueID, voterAddr, votingTargetAddr string, vo
 		return nil, err
 	}
 
-	sign, err := key.Sign(bytes)
+	sig, err := key.Sign(bytes)
 	if err != nil {
 		return nil, err
 	}
 
 	msgVoteOracleRegistration := &types.MsgVoteOracleRegistration{
 		OracleRegistrationVote: registrationVote,
-		Signature:              sign,
+		Signature:              sig,
 	}
 
 	return msgVoteOracleRegistration, nil
@@ -154,8 +154,8 @@ func generateTxBytes(msgVoteOracleRegistration *types.MsgVoteOracleRegistration,
 	return txBytes, nil
 }
 
-// broadCastTx
-func broadCastTx(grpcClient *panacea.GrpcClient, txBytes []byte) error {
+// broadcastTx
+func broadcastTx(grpcClient *panacea.GrpcClient, txBytes []byte) error {
 	resp, err := grpcClient.BroadcastTx(txBytes)
 	if err != nil {
 		return err

--- a/event/register_oracle_event.go
+++ b/event/register_oracle_event.go
@@ -87,6 +87,7 @@ func (e RegisterOracleEvent) EventHandler(event ctypes.ResultEvent) error {
 	return nil
 }
 
+// makeOracleRegistrationVote makes a vote for oracle registration with VOTE_OPTION
 func makeOracleRegistrationVote(uniqueID, voterAddr, votingTargetAddr string, voteOption types.VoteOption, oraclePrivKey []byte) (*types.MsgVoteOracleRegistration, error) {
 	registrationVote := &types.OracleRegistrationVote{
 		UniqueId:               uniqueID,
@@ -115,6 +116,7 @@ func makeOracleRegistrationVote(uniqueID, voterAddr, votingTargetAddr string, vo
 	return msgVoteOracleRegistrationNo, nil
 }
 
+// generateTxBytes
 func generateTxBytes(msgVoteOracleRegistration *types.MsgVoteOracleRegistration, privKey cryptotypes.PrivKey, conf *config.Config, txBuilder *panacea.TxBuilder) ([]byte, error) {
 	defaultFeeAmount, _ := sdk.ParseCoinsNormalized(conf.Panacea.DefaultFeeAmount)
 	txBytes, err := txBuilder.GenerateSignedTxBytes(privKey, conf.Panacea.DefaultGasLimit, defaultFeeAmount, msgVoteOracleRegistration)
@@ -125,6 +127,7 @@ func generateTxBytes(msgVoteOracleRegistration *types.MsgVoteOracleRegistration,
 	return txBytes, nil
 }
 
+// broadCastTx
 func broadCastTx(grpcClient *panacea.GrpcClient, txBytes []byte) error {
 	resp, err := grpcClient.BroadcastTx(txBytes)
 	if err != nil {

--- a/event/register_oracle_event.go
+++ b/event/register_oracle_event.go
@@ -56,9 +56,7 @@ func (e RegisterOracleEvent) EventHandler(event ctypes.ResultEvent) error {
 		return err
 	}
 
-	nodePubKeyHash := sha256.Sum256(oracleRegistration.NodePubKey)
-
-	voteOption := verifyReportAndGetVoteOption(oracleRegistration, nodePubKeyHash, e)
+	voteOption := verifyReportAndGetVoteOption(oracleRegistration, e)
 
 	msgVoteOracleRegistration, err := makeOracleRegistrationVote(uniqueID, e.reactor.OracleAcc().GetAddress(), addressValue, voteOption, e.reactor.OraclePrivKey())
 	if err != nil {
@@ -78,7 +76,9 @@ func (e RegisterOracleEvent) EventHandler(event ctypes.ResultEvent) error {
 }
 
 // verifyReportAndGetVoteOption validates the RemoteReport and returns the voting result according to the verification result.
-func verifyReportAndGetVoteOption(oracleRegistration *types.OracleRegistration, nodePubKeyHash [32]byte, e RegisterOracleEvent) types.VoteOption {
+func verifyReportAndGetVoteOption(oracleRegistration *types.OracleRegistration, e RegisterOracleEvent) types.VoteOption {
+	nodePubKeyHash := sha256.Sum256(oracleRegistration.NodePubKey)
+
 	if err := sgx.VerifyRemoteReport(oracleRegistration.NodePubKeyRemoteReport, nodePubKeyHash[:], *e.reactor.EnclaveInfo()); err != nil {
 		log.Infof("failed to verification report. uniqueID(%s), address(%s), err(%v)", oracleRegistration.UniqueId, oracleRegistration.Address, err)
 		return types.VOTE_OPTION_NO

--- a/event/register_oracle_event.go
+++ b/event/register_oracle_event.go
@@ -10,6 +10,7 @@ import (
 	"github.com/medibloc/panacea-doracle/config"
 	"github.com/medibloc/panacea-doracle/panacea"
 	"github.com/medibloc/panacea-doracle/sgx"
+	log "github.com/sirupsen/logrus"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 )
 
@@ -84,6 +85,7 @@ func (e RegisterOracleEvent) EventHandler(event ctypes.ResultEvent) error {
 		return err
 	}
 
+	log.Info("oracle registration success")
 	return nil
 }
 

--- a/event/register_oracle_event.go
+++ b/event/register_oracle_event.go
@@ -2,9 +2,12 @@ package event
 
 import (
 	"encoding/hex"
-	"github.com/medibloc/panacea-doracle/service"
-
+	"fmt"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/medibloc/panacea-core/v2/x/oracle/types"
+	"github.com/medibloc/panacea-doracle/config"
 	"github.com/medibloc/panacea-doracle/panacea"
 	"github.com/medibloc/panacea-doracle/sgx"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
@@ -20,6 +23,10 @@ type RegisterOracleEvent struct {
 type reactor interface {
 	GRPCClient() *panacea.GrpcClient
 	EnclaveInfo() *sgx.EnclaveInfo
+	OracleAcc() *panacea.OracleAccount
+	OraclePrivKey() []byte
+	TxBuilder() *panacea.TxBuilder
+	Config() *config.Config
 }
 
 func NewRegisterOracleEvent(r reactor) RegisterOracleEvent {
@@ -49,34 +56,83 @@ func (e RegisterOracleEvent) EventHandler(event ctypes.ResultEvent) error {
 
 	err = sgx.VerifyRemoteReport(oracleRegistration.NodePubKeyRemoteReport, oracleRegistration.NodePubKey, *e.reactor.EnclaveInfo())
 	if err != nil {
+		msgVoteOracleRegistrationNo, err := makeOracleRegistrationVote(uniqueID, e.reactor.OracleAcc().GetAddress(), addressValue, types.VOTE_OPTION_NO, e.reactor.OraclePrivKey())
+		if err != nil {
+			return err
+		}
+
+		txBytes, err := generateTxBytes(msgVoteOracleRegistrationNo, e.reactor.OracleAcc().GetPrivKey(), e.reactor.Config(), e.reactor.TxBuilder())
+		if err != nil {
+			return err
+		}
+
+		err = broadCastTx(e.reactor.GRPCClient(), txBytes)
+		if err != nil {
+			return err
+		}
 		return err
 	}
 
-	// TODO: Executing Vote Txs
+	msgVoteOracleRegistrationYes, err := makeOracleRegistrationVote(uniqueID, e.reactor.OracleAcc().GetAddress(), addressValue, types.VOTE_OPTION_YES, e.reactor.OraclePrivKey())
+	txBytes, err := generateTxBytes(msgVoteOracleRegistrationYes, e.reactor.OracleAcc().GetPrivKey(), e.reactor.Config(), e.reactor.TxBuilder())
+	if err != nil {
+		return err
+	}
+
+	err = broadCastTx(e.reactor.GRPCClient(), txBytes)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
 
-func yesVote(selfEnclave *sgx.EnclaveInfo, svc *service.Service, address string) types.OracleRegistrationVote {
-	registrationVoteYes := types.OracleRegistrationVote{
-		UniqueId:               hex.EncodeToString(selfEnclave.UniqueID),
-		VoterAddress:           svc.OracleAccount.GetAddress(),
-		VotingTargetAddress:    address,
-		VoteOption:             types.VOTE_OPTION_YES,
-		EncryptedOraclePrivKey: svc.OraclePrivKey,
+func makeOracleRegistrationVote(uniqueID, voterAddr, votingTargetAddr string, voteOption types.VoteOption, oraclePrivKey []byte) (*types.MsgVoteOracleRegistration, error) {
+	registrationVote := &types.OracleRegistrationVote{
+		UniqueId:               uniqueID,
+		VoterAddress:           voterAddr,
+		VotingTargetAddress:    votingTargetAddr,
+		VoteOption:             voteOption,
+		EncryptedOraclePrivKey: oraclePrivKey,
 	}
 
-	return registrationVoteYes
+	key := secp256k1.PrivKey{
+		Key: oraclePrivKey,
+	}
+
+	bytes, err := registrationVote.Marshal()
+
+	sign, err := key.Sign(bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	msgVoteOracleRegistrationNo := &types.MsgVoteOracleRegistration{
+		OracleRegistrationVote: registrationVote,
+		Signature:              sign,
+	}
+
+	return msgVoteOracleRegistrationNo, nil
 }
 
-func noVote(selfEnclave *sgx.EnclaveInfo, svc *service.Service, address string) types.OracleRegistrationVote {
-	registrationVoteNo := types.OracleRegistrationVote{
-		UniqueId:               hex.EncodeToString(selfEnclave.UniqueID),
-		VoterAddress:           svc.OracleAccount.GetAddress(),
-		VotingTargetAddress:    address,
-		VoteOption:             types.VOTE_OPTION_NO,
-		EncryptedOraclePrivKey: svc.OraclePrivKey,
+func generateTxBytes(msgVoteOracleRegistration *types.MsgVoteOracleRegistration, privKey cryptotypes.PrivKey, conf *config.Config, txBuilder *panacea.TxBuilder) ([]byte, error) {
+	defaultFeeAmount, _ := sdk.ParseCoinsNormalized(conf.Panacea.DefaultFeeAmount)
+	txBytes, err := txBuilder.GenerateSignedTxBytes(privKey, conf.Panacea.DefaultGasLimit, defaultFeeAmount, msgVoteOracleRegistration)
+	if err != nil {
+		return nil, err
 	}
 
-	return registrationVoteNo
+	return txBytes, nil
+}
+
+func broadCastTx(grpcClient *panacea.GrpcClient, txBytes []byte) error {
+	resp, err := grpcClient.BroadcastTx(txBytes)
+	if err != nil {
+		return err
+	}
+
+	if resp.TxResponse.Code != 0 {
+		return fmt.Errorf("register oracle vote failed: %v", resp.TxResponse.RawLog)
+	}
+	return nil
 }

--- a/event/register_oracle_event.go
+++ b/event/register_oracle_event.go
@@ -77,6 +77,10 @@ func (e RegisterOracleEvent) EventHandler(event ctypes.ResultEvent) error {
 	}
 
 	msgVoteOracleRegistrationYes, err := makeOracleRegistrationVote(uniqueID, e.reactor.OracleAcc().GetAddress(), addressValue, types.VOTE_OPTION_YES, e.reactor.OraclePrivKey())
+	if err != nil {
+		 return err
+	}
+
 	txBytes, err := generateTxBytes(msgVoteOracleRegistrationYes, e.reactor.OracleAcc().GetPrivKey(), e.reactor.Config(), e.reactor.TxBuilder())
 	if err != nil {
 		return err
@@ -105,6 +109,9 @@ func makeOracleRegistrationVote(uniqueID, voterAddr, votingTargetAddr string, vo
 	}
 
 	bytes, err := registrationVote.Marshal()
+	if err != nil {
+		return nil, err
+	}
 
 	sign, err := key.Sign(bytes)
 	if err != nil {

--- a/event/register_oracle_event.go
+++ b/event/register_oracle_event.go
@@ -56,11 +56,11 @@ func (e RegisterOracleEvent) EventHandler(event ctypes.ResultEvent) error {
 		return err
 	}
 
-	fmt.Println(oracleRegistration)
 	nodePubKeyHash := sha256.Sum256(oracleRegistration.NodePubKey)
 
 	err = sgx.VerifyRemoteReport(oracleRegistration.NodePubKeyRemoteReport, nodePubKeyHash[:], *e.reactor.EnclaveInfo())
 	if err != nil {
+		fmt.Println("oracle registration vote NO success")
 		msgVoteOracleRegistrationNo, err := makeOracleRegistrationVote(uniqueID, e.reactor.OracleAcc().GetAddress(), addressValue, types.VOTE_OPTION_NO, e.reactor.OraclePrivKey())
 		if err != nil {
 			return err
@@ -89,7 +89,7 @@ func (e RegisterOracleEvent) EventHandler(event ctypes.ResultEvent) error {
 		return err
 	}
 
-	log.Info("oracle registration success")
+	log.Info("oracle registration vote YES success")
 	return nil
 }
 
@@ -126,7 +126,6 @@ func makeOracleRegistrationVote(uniqueID, voterAddr, votingTargetAddr string, vo
 func generateTxBytes(msgVoteOracleRegistration *types.MsgVoteOracleRegistration, privKey cryptotypes.PrivKey, conf *config.Config, txBuilder *panacea.TxBuilder) ([]byte, error) {
 	defaultFeeAmount, _ := sdk.ParseCoinsNormalized(conf.Panacea.DefaultFeeAmount)
 	txBytes, err := txBuilder.GenerateSignedTxBytes(privKey, conf.Panacea.DefaultGasLimit, defaultFeeAmount, msgVoteOracleRegistration)
-	fmt.Printf("Generate Tx Error, %v", err)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +139,6 @@ func broadCastTx(grpcClient *panacea.GrpcClient, txBytes []byte) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Broadcast Tx Error, %v", err)
 
 	if resp.TxResponse.Code != 0 {
 		return fmt.Errorf("register oracle vote failed: %v", resp.TxResponse.RawLog)

--- a/event/register_oracle_event.go
+++ b/event/register_oracle_event.go
@@ -111,12 +111,12 @@ func makeOracleRegistrationVote(uniqueID, voterAddr, votingTargetAddr string, vo
 		return nil, err
 	}
 
-	msgVoteOracleRegistrationNo := &types.MsgVoteOracleRegistration{
+	msgVoteOracleRegistration := &types.MsgVoteOracleRegistration{
 		OracleRegistrationVote: registrationVote,
 		Signature:              sign,
 	}
 
-	return msgVoteOracleRegistrationNo, nil
+	return msgVoteOracleRegistration, nil
 }
 
 // generateTxBytes
@@ -138,7 +138,10 @@ func broadCastTx(grpcClient *panacea.GrpcClient, txBytes []byte) error {
 	}
 
 	if resp.TxResponse.Code != 0 {
-		return fmt.Errorf("register oracle vote failed: %v", resp.TxResponse.RawLog)
+		return fmt.Errorf("register oracle vote trasnsaction failed: %v", resp.TxResponse.RawLog)
 	}
+
+	log.Infof("MsgVoteOracleRegistration transaction succeed. height(%v), hash(%s)", resp.TxResponse.Height, resp.TxResponse.TxHash)
+
 	return nil
 }

--- a/event/register_oracle_event.go
+++ b/event/register_oracle_event.go
@@ -55,6 +55,8 @@ func (e RegisterOracleEvent) EventHandler(event ctypes.ResultEvent) error {
 		return err
 	}
 
+	fmt.Println(oracleRegistration)
+
 	err = sgx.VerifyRemoteReport(oracleRegistration.NodePubKeyRemoteReport, oracleRegistration.NodePubKey, *e.reactor.EnclaveInfo())
 	if err != nil {
 		msgVoteOracleRegistrationNo, err := makeOracleRegistrationVote(uniqueID, e.reactor.OracleAcc().GetAddress(), addressValue, types.VOTE_OPTION_NO, e.reactor.OraclePrivKey())

--- a/event/register_oracle_event.go
+++ b/event/register_oracle_event.go
@@ -11,7 +11,6 @@ import (
 	"github.com/medibloc/panacea-doracle/config"
 	"github.com/medibloc/panacea-doracle/panacea"
 	"github.com/medibloc/panacea-doracle/sgx"
-	log "github.com/sirupsen/logrus"
 	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 )
 
@@ -60,7 +59,6 @@ func (e RegisterOracleEvent) EventHandler(event ctypes.ResultEvent) error {
 
 	err = sgx.VerifyRemoteReport(oracleRegistration.NodePubKeyRemoteReport, nodePubKeyHash[:], *e.reactor.EnclaveInfo())
 	if err != nil {
-		fmt.Println("oracle registration vote NO success")
 		msgVoteOracleRegistrationNo, err := makeOracleRegistrationVote(uniqueID, e.reactor.OracleAcc().GetAddress(), addressValue, types.VOTE_OPTION_NO, e.reactor.OraclePrivKey())
 		if err != nil {
 			return err
@@ -89,7 +87,6 @@ func (e RegisterOracleEvent) EventHandler(event ctypes.ResultEvent) error {
 		return err
 	}
 
-	log.Info("oracle registration vote YES success")
 	return nil
 }
 

--- a/event/register_oracle_event.go
+++ b/event/register_oracle_event.go
@@ -124,6 +124,7 @@ func makeOracleRegistrationVote(uniqueID, voterAddr, votingTargetAddr string, vo
 func generateTxBytes(msgVoteOracleRegistration *types.MsgVoteOracleRegistration, privKey cryptotypes.PrivKey, conf *config.Config, txBuilder *panacea.TxBuilder) ([]byte, error) {
 	defaultFeeAmount, _ := sdk.ParseCoinsNormalized(conf.Panacea.DefaultFeeAmount)
 	txBytes, err := txBuilder.GenerateSignedTxBytes(privKey, conf.Panacea.DefaultGasLimit, defaultFeeAmount, msgVoteOracleRegistration)
+	fmt.Printf("Generate Tx Error, %v", err)
 	if err != nil {
 		return nil, err
 	}
@@ -137,6 +138,7 @@ func broadCastTx(grpcClient *panacea.GrpcClient, txBytes []byte) error {
 	if err != nil {
 		return err
 	}
+	fmt.Printf("Broadcast Tx Error, %v", err)
 
 	if resp.TxResponse.Code != 0 {
 		return fmt.Errorf("register oracle vote failed: %v", resp.TxResponse.RawLog)

--- a/event/register_oracle_event.go
+++ b/event/register_oracle_event.go
@@ -38,5 +38,30 @@ func (e RegisterOracleEvent) EventHandler(event ctypes.ResultEvent, svc *service
 	}
 
 	// TODO: Executing Vote Txs
+	
 	return nil
+}
+
+func yesVote(selfEnclave *sgx.EnclaveInfo, svc *service.Service, address string) types.OracleRegistrationVote {
+	registrationVoteYes := types.OracleRegistrationVote{
+		UniqueId:               hex.EncodeToString(selfEnclave.UniqueID),
+		VoterAddress:           svc.OracleAccount.GetAddress(),
+		VotingTargetAddress:    address,
+		VoteOption:             types.VOTE_OPTION_YES,
+		EncryptedOraclePrivKey: svc.OraclePrivKey,
+	}
+
+	return registrationVoteYes
+}
+
+func noVote(selfEnclave *sgx.EnclaveInfo, svc *service.Service, address string) types.OracleRegistrationVote {
+	registrationVoteNo := types.OracleRegistrationVote{
+		UniqueId:               hex.EncodeToString(selfEnclave.UniqueID),
+		VoterAddress:           svc.OracleAccount.GetAddress(),
+		VotingTargetAddress:    address,
+		VoteOption:             types.VOTE_OPTION_NO,
+		EncryptedOraclePrivKey: svc.OraclePrivKey,
+	}
+
+	return registrationVoteNo
 }

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/cosmos/go-bip39 v1.0.0
 	github.com/cosmos/ibc-go/v2 v2.0.3
 	github.com/edgelesssys/ego v1.0.0
-	github.com/medibloc/panacea-core/v2 v2.1.0-alpha2.0.20220831095508-d3e1046fa5f2
+	github.com/medibloc/panacea-core/v2 v2.1.0-alpha2.0.20220906045844-3151be7c430e
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/viper v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -667,6 +667,8 @@ github.com/medibloc/panacea-core/v2 v2.1.0-alpha2.0.20220825075207-8bef1f5963b6 
 github.com/medibloc/panacea-core/v2 v2.1.0-alpha2.0.20220825075207-8bef1f5963b6/go.mod h1:l9fOSt3J2e5jUKrMnd/wD6etXymvoKbByW5f2V4gZu4=
 github.com/medibloc/panacea-core/v2 v2.1.0-alpha2.0.20220831095508-d3e1046fa5f2 h1:nwhZ7huWWYpgRRH+yXzxZ20y9kXa1CZbST3vVmXk2IU=
 github.com/medibloc/panacea-core/v2 v2.1.0-alpha2.0.20220831095508-d3e1046fa5f2/go.mod h1:l9fOSt3J2e5jUKrMnd/wD6etXymvoKbByW5f2V4gZu4=
+github.com/medibloc/panacea-core/v2 v2.1.0-alpha2.0.20220906045844-3151be7c430e h1:aCbbtSQq9i7zO1EHO8VEVLGueJWBn+qwkE04Q6poAJ8=
+github.com/medibloc/panacea-core/v2 v2.1.0-alpha2.0.20220906045844-3151be7c430e/go.mod h1:l9fOSt3J2e5jUKrMnd/wD6etXymvoKbByW5f2V4gZu4=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=

--- a/go.sum
+++ b/go.sum
@@ -663,10 +663,6 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0j
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/medibloc/cosmos-sdk v0.45.4-panacea h1:j5IV+xx9S8obSFkqOQwGG3Lt6ErCKq2s01iShjz3ntQ=
 github.com/medibloc/cosmos-sdk v0.45.4-panacea/go.mod h1:WOqtDxN3eCCmnYLVla10xG7lEXkFjpTaqm2a2WasgCc=
-github.com/medibloc/panacea-core/v2 v2.1.0-alpha2.0.20220825075207-8bef1f5963b6 h1:B8T9CWym7VO2vAv8U1CptSM/c8Ovo9sfg8wx06Q0zSU=
-github.com/medibloc/panacea-core/v2 v2.1.0-alpha2.0.20220825075207-8bef1f5963b6/go.mod h1:l9fOSt3J2e5jUKrMnd/wD6etXymvoKbByW5f2V4gZu4=
-github.com/medibloc/panacea-core/v2 v2.1.0-alpha2.0.20220831095508-d3e1046fa5f2 h1:nwhZ7huWWYpgRRH+yXzxZ20y9kXa1CZbST3vVmXk2IU=
-github.com/medibloc/panacea-core/v2 v2.1.0-alpha2.0.20220831095508-d3e1046fa5f2/go.mod h1:l9fOSt3J2e5jUKrMnd/wD6etXymvoKbByW5f2V4gZu4=
 github.com/medibloc/panacea-core/v2 v2.1.0-alpha2.0.20220906045844-3151be7c430e h1:aCbbtSQq9i7zO1EHO8VEVLGueJWBn+qwkE04Q6poAJ8=
 github.com/medibloc/panacea-core/v2 v2.1.0-alpha2.0.20220906045844-3151be7c430e/go.mod h1:l9fOSt3J2e5jUKrMnd/wD6etXymvoKbByW5f2V4gZu4=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=

--- a/panacea/query_client.go
+++ b/panacea/query_client.go
@@ -36,10 +36,10 @@ type TrustedBlockInfo struct {
 }
 
 type QueryClient struct {
-	rpcClient         *rpchttp.HTTP
-	lightClient       *light.Client
-	sgxLevelDB        *sgxdb.SgxLevelDB
-	mutex             *sync.Mutex
+	rpcClient   *rpchttp.HTTP
+	lightClient *light.Client
+	sgxLevelDB  *sgxdb.SgxLevelDB
+	mutex       *sync.Mutex
 	cdc         *codec.ProtoCodec
 	chainID     string
 }
@@ -131,8 +131,8 @@ func newQueryClient(ctx context.Context, config *config.Config, info *TrustedBlo
 	}()
 
 	return &QueryClient{
-		rpcClient:         rpcClient,
-		lightClient:       lc,
+		rpcClient:   rpcClient,
+		lightClient: lc,
 		sgxLevelDB:  db,
 		mutex:       &lcMutex,
 		cdc:         codec.NewProtoCodec(makeInterfaceRegistry()),

--- a/service/service.go
+++ b/service/service.go
@@ -18,12 +18,13 @@ type Service struct {
 	conf        *config.Config
 	enclaveInfo *sgx.EnclaveInfo
 
-	OracleAccount *panacea.OracleAccount
-	OraclePrivKey []byte
+	oracleAccount *panacea.OracleAccount
+	oraclePrivKey []byte
 
 	// queryClient *panacea.QueryClient //TODO: uncomment this
 	grpcClient *panacea.GrpcClient
 	subscriber *event.PanaceaSubscriber
+	txBuilder  *panacea.TxBuilder
 }
 
 func New(conf *config.Config, oracleAccount *panacea.OracleAccount) (*Service, error) {
@@ -54,6 +55,8 @@ func New(conf *config.Config, oracleAccount *panacea.OracleAccount) (*Service, e
 		return nil, fmt.Errorf("failed to init subscriber: %w", err)
 	}
 
+	txBuilder := panacea.NewTxBuilder(grpcClient)
+
 	return &Service{
 		conf:          conf,
 		oracleAccount: oracleAccount,
@@ -61,6 +64,7 @@ func New(conf *config.Config, oracleAccount *panacea.OracleAccount) (*Service, e
 		enclaveInfo:   selfEnclaveInfo,
 		grpcClient:    grpcClient.(*panacea.GrpcClient),
 		subscriber:    subscriber,
+		txBuilder:     txBuilder,
 	}, nil
 }
 
@@ -80,10 +84,26 @@ func (s *Service) Close() error {
 	return nil
 }
 
-func (s *Service) GRPCClient() *panacea.GrpcClient {
-	return s.grpcClient
+func (s *Service) Config() *config.Config {
+	return s.conf
+}
+
+func (s *Service) OracleAcc() *panacea.OracleAccount {
+	return s.oracleAccount
+}
+
+func (s *Service) OraclePrivKey() []byte {
+	return s.oraclePrivKey
 }
 
 func (s *Service) EnclaveInfo() *sgx.EnclaveInfo {
 	return s.enclaveInfo
+}
+
+func (s *Service) GRPCClient() *panacea.GrpcClient {
+	return s.grpcClient
+}
+
+func (s *Service) TxBuilder() *panacea.TxBuilder {
+	return s.txBuilder
 }

--- a/service/service.go
+++ b/service/service.go
@@ -2,9 +2,7 @@ package service
 
 import (
 	"fmt"
-	"github.com/btcsuite/btcd/btcec"
 	"github.com/medibloc/panacea-doracle/config"
-	"github.com/medibloc/panacea-doracle/crypto"
 	"github.com/medibloc/panacea-doracle/panacea"
 	"github.com/medibloc/panacea-doracle/sgx"
 	"github.com/medibloc/panacea-doracle/types"
@@ -15,7 +13,7 @@ import (
 type Service struct {
 	Conf          *config.Config
 	OracleAccount *panacea.OracleAccount
-	OraclePrivKey *btcec.PrivateKey
+	OraclePrivKey []byte
 	EnclaveInfo   *sgx.EnclaveInfo
 
 	QueryClient *panacea.QueryClient
@@ -29,11 +27,10 @@ func New(conf *config.Config) (*Service, error) {
 	}
 
 	oraclePrivKeyPath := filepath.Join(homeDir, ".doracle", types.DefaultOraclePrivKeyName)
-	oraclePrivKeyBz, err := sgx.UnsealFromFile(oraclePrivKeyPath)
+	oraclePrivKey, err := sgx.UnsealFromFile(oraclePrivKeyPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unseal oracle_priv_key.sealed file: %w", err)
 	}
-	oraclePrivKey, _ := crypto.PrivKeyFromBytes(oraclePrivKeyBz)
 
 	selfEnclaveInfo, err := sgx.GetSelfEnclaveInfo()
 	if err != nil {


### PR DESCRIPTION
- Implement executing vote transaction after verify remote report.
- Executing Vote with `makeOracleRegistrationVote`, `generateTx`, and `broadcastTx` function in `event/register_oracle_event.go`.
- This feature works well when [this branch](https://github.com/medibloc/panacea-core/pull/400) merged into master.