### PR TITLE
feat: convert grpc query to light client based query

### DIFF
--- a/cmd/doracled/cmd/gen_oracle_key.go
+++ b/cmd/doracled/cmd/gen_oracle_key.go
@@ -22,59 +22,62 @@ type OraclePubKeyInfo struct {
 	RemoteReportBase64 string `json:"remote_report_base64"`
 }
 
-var genOracleKeyCmd = &cobra.Command{
-	Use:   "gen-oracle-key",
-	Short: "Generate oracle key and its remote report",
-	Long: `Generate a new pair of oracle key and its remote report. 
+func genOracleKeyCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "gen-oracle-key",
+		Short: "Generate oracle key and its remote report",
+		Long: `Generate a new pair of oracle key and its remote report. 
 If the sealed oracle private key exist already, this command will replace the existing one.
 So please be cautious in using this command.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		conf, err := loadConfigFromHome(cmd)
-		if err != nil {
-			return err
-		}
-
-		// If there is the existing oracle key, double-check for generating a new oracle key
-		oraclePrivKeyPath := conf.AbsOraclePrivKeyPath()
-		if tos.FileExists(oraclePrivKeyPath) {
-			buf := bufio.NewReader(os.Stdin)
-			ok, err := input.GetConfirmation("This can replace the existing oracle-key.sealed file.\nAre you sure to make a new oracle key?", buf, os.Stderr)
-
-			if err != nil || !ok {
-				log.Printf("Oracle key generation is canceled.")
+		RunE: func(cmd *cobra.Command, args []string) error {
+			conf, err := loadConfigFromHome(cmd)
+			if err != nil {
 				return err
 			}
-		}
 
-		// generate a new oracle key
-		oraclePrivKey, err := crypto.NewPrivKey()
-		if err != nil {
-			log.Errorf("failed to generate oracle key: %v", err)
-			return err
-		}
+			// If there is the existing oracle key, double-check for generating a new oracle key
+			oraclePrivKeyPath := conf.AbsOraclePrivKeyPath()
+			if tos.FileExists(oraclePrivKeyPath) {
+				buf := bufio.NewReader(os.Stdin)
+				ok, err := input.GetConfirmation("This can replace the existing oracle-key.sealed file.\nAre you sure to make a new oracle key?", buf, os.Stderr)
 
-		// seal and store oracle private key
-		if err := sgx.SealToFile(oraclePrivKey.Serialize(), oraclePrivKeyPath); err != nil {
-			log.Errorf("failed to write %s: %v", oraclePrivKeyPath, err)
-			return err
-		}
+				if err != nil || !ok {
+					log.Printf("Oracle key generation is canceled.")
+					return err
+				}
+			}
 
-		// generate oracle key remote report
-		oraclePubKey := oraclePrivKey.PubKey().SerializeCompressed()
-		oracleKeyRemoteReport, err := sgx.GenerateRemoteReport(oraclePubKey)
-		if err != nil {
-			log.Errorf("failed to generate remote report of oracle key: %v", err)
-			return err
-		}
+			// generate a new oracle key
+			oraclePrivKey, err := crypto.NewPrivKey()
+			if err != nil {
+				log.Errorf("failed to generate oracle key: %v", err)
+				return err
+			}
 
-		// store oracle pub key and its remote report to a file
-		if err := storeOraclePubKey(oraclePubKey, oracleKeyRemoteReport, conf.AbsOraclePubKeyPath()); err != nil {
-			log.Errorf("failed to save oracle pub key and its remote report: %v", err)
-			return err
-		}
+			// seal and store oracle private key
+			if err := sgx.SealToFile(oraclePrivKey.Serialize(), oraclePrivKeyPath); err != nil {
+				log.Errorf("failed to write %s: %v", oraclePrivKeyPath, err)
+				return err
+			}
 
-		return nil
-	},
+			// generate oracle key remote report
+			oraclePubKey := oraclePrivKey.PubKey().SerializeCompressed()
+			oracleKeyRemoteReport, err := sgx.GenerateRemoteReport(oraclePubKey)
+			if err != nil {
+				log.Errorf("failed to generate remote report of oracle key: %v", err)
+				return err
+			}
+
+			// store oracle pub key and its remote report to a file
+			if err := storeOraclePubKey(oraclePubKey, oracleKeyRemoteReport, conf.AbsOraclePubKeyPath()); err != nil {
+				log.Errorf("failed to save oracle pub key and its remote report: %v", err)
+				return err
+			}
+
+			return nil
+		},
+	}
+	return cmd
 }
 
 // storeOraclePubKey stores base64-encoded oracle public key and its remote report

--- a/cmd/doracled/cmd/get_oracle_key.go
+++ b/cmd/doracled/cmd/get_oracle_key.go
@@ -2,12 +2,13 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"errors"
 	"fmt"
-
 	"github.com/btcsuite/btcd/btcec"
 	oracletypes "github.com/medibloc/panacea-core/v2/x/oracle/types"
+	"github.com/medibloc/panacea-doracle/client/flags"
 	"github.com/medibloc/panacea-doracle/config"
 	"github.com/medibloc/panacea-doracle/crypto"
 	"github.com/medibloc/panacea-doracle/panacea"
@@ -17,69 +18,74 @@ import (
 	tos "github.com/tendermint/tendermint/libs/os"
 )
 
-var getOracleKeyCmd = &cobra.Command{
-	Use:   "get-oracle-key",
-	Short: "Get a shared oracle private key",
-	Long: `Get a shared oracle private key from Panacea.
-The encrypted oracle private key can only be decrypted using the node key, which is generated in SGX-enabled environment.
-The node key must be the same with the one stored in OracleRegistration KV store in Panacea.
-After decrypted, the oracle private key is sealed and stored as a file named oracle_priv_key.sealed securely.
-This oracle private key can also be accessed in SGX-enabled environment using the promised binary.
-`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		conf, err := loadConfigFromHome(cmd)
-		if err != nil {
-			return err
-		}
+func getOracleKeyCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get-oracle-key",
+		Short: "Get a shared oracle private key",
+		Long: `Get a shared oracle private key from Panacea.
+		The encrypted oracle private key can only be decrypted using the node key, which is generated in SGX-enabled environment.
+		The node key must be the same with the one stored in OracleRegistration KV store in Panacea.
+		After decrypted, the oracle private key is sealed and stored as a file named oracle_priv_key.sealed securely.
+		This oracle private key can also be accessed in SGX-enabled environment using the promised binary.
+		`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			conf, err := loadConfigFromHome(cmd)
+			if err != nil {
+				return err
+			}
 
-		// if there is a node key already, return error
-		nodePrivKeyPath := conf.AbsNodePrivKeyPath()
-		if !tos.FileExists(nodePrivKeyPath) {
-			return errors.New("no node_priv_key.sealed file")
-		}
+			ctx := context.Background()
 
-		// get existing node key
-		nodePrivKeyBz, err := sgx.UnsealFromFile(nodePrivKeyPath)
-		if err != nil {
-			return fmt.Errorf("failed to unseal node_priv_key.sealed file: %w", err)
-		}
-		nodePrivKey, nodePubKey := crypto.PrivKeyFromBytes(nodePrivKeyBz)
+			// if there is a node key already, return error
+			nodePrivKeyPath := conf.AbsNodePrivKeyPath()
+			if !tos.FileExists(nodePrivKeyPath) {
+				return errors.New("no node_priv_key.sealed file")
+			}
 
-		// get unique ID
-		selfEnclaveInfo, err := sgx.GetSelfEnclaveInfo()
-		if err != nil {
-			return fmt.Errorf("failed to get self enclave info: %w", err)
-		}
-		uniqueID := hex.EncodeToString(selfEnclaveInfo.UniqueID)
+			// get existing node key
+			nodePrivKeyBz, err := sgx.UnsealFromFile(nodePrivKeyPath)
+			if err != nil {
+				return fmt.Errorf("failed to unseal node_priv_key.sealed file: %w", err)
+			}
+			nodePrivKey, nodePubKey := crypto.PrivKeyFromBytes(nodePrivKeyBz)
 
-		// get oracle account from mnemonic.
-		oracleAccount, err := getOracleAccount(cmd, conf.OracleMnemonic)
-		if err != nil {
-			return fmt.Errorf("failed to get oracle account from mnemonic: %w", err)
-		}
+			// get unique ID
+			selfEnclaveInfo, err := sgx.GetSelfEnclaveInfo()
+			if err != nil {
+				return fmt.Errorf("failed to get self enclave info: %w", err)
+			}
+			uniqueID := hex.EncodeToString(selfEnclaveInfo.UniqueID)
 
-		// TODO: replace to use query client
-		// get OracleRegistration from Panacea
-		cli, err := panacea.NewGrpcClient(conf)
-		if err != nil {
-			return fmt.Errorf("failed to create gRPC client: %w", err)
-		}
-		defer func() {
-			_ = cli.Close()
-		}()
+			// get oracle account from mnemonic.
+			oracleAccount, err := getOracleAccount(cmd, conf.OracleMnemonic)
+			if err != nil {
+				return fmt.Errorf("failed to get oracle account from mnemonic: %w", err)
+			}
 
-		oracleRegistration, err := cli.GetOracleRegistration(oracleAccount.GetAddress(), uniqueID)
-		if err != nil {
-			return fmt.Errorf("failed to get oracle registration from Panacea: %w", err)
-		}
+			// get OracleRegistration from Panacea
+			queryClient, err := panacea.LoadQueryClient(ctx, conf)
+			if err != nil {
+				return fmt.Errorf("failed to get queryClient: %w", err)
+			}
+			defer queryClient.Close()
 
-		// check if the same node key is used for oracle registration
-		if !bytes.Equal(oracleRegistration.NodePubKey, nodePubKey.SerializeCompressed()) {
-			return errors.New("the existing node key is different from the one used in oracle registration. if you want to re-request RegisterOracle, delete the existing node_priv_key.sealed file and rerun register-oracle cmd")
-		}
+			oracleRegistration, err := queryClient.GetOracleRegistration(oracleAccount.GetAddress(), uniqueID)
+			if err != nil {
+				return fmt.Errorf("failed to get oracle registration from Panacea: %w", err)
+			}
 
-		return getOraclePrivKey(conf, oracleRegistration, nodePrivKey)
-	},
+			// check if the same node key is used for oracle registration
+			if !bytes.Equal(oracleRegistration.NodePubKey, nodePubKey.SerializeCompressed()) {
+				return errors.New("the existing node key is different from the one used in oracle registration. if you want to re-request RegisterOracle, delete the existing node_priv_key.sealed file and rerun register-oracle cmd")
+			}
+
+			return getOraclePrivKey(conf, oracleRegistration, nodePrivKey)
+		},
+	}
+	cmd.Flags().Uint32P(flags.FlagAccNum, "a", 0, "Account number of oracle")
+	cmd.Flags().Uint32P(flags.FlagIndex, "i", 0, "Address index number for HD derivation of oracle")
+
+	return cmd
 }
 
 // getOraclePrivKey handles OracleRegistration differently depending on the status of oracle registration

--- a/cmd/doracled/cmd/init.go
+++ b/cmd/doracled/cmd/init.go
@@ -14,34 +14,37 @@ const (
 	configFileName = "config.toml"
 )
 
-var initCmd = &cobra.Command{
-	Use:   "init",
-	Short: "Initialize configs in home dir",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		homeDir, err := cmd.Flags().GetString(flags.FlagHome)
-		if err != nil {
-			return fmt.Errorf("failed to read a home flag: %w", err)
-		}
+func initCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Initialize configs in home dir",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			homeDir, err := cmd.Flags().GetString(flags.FlagHome)
+			if err != nil {
+				return fmt.Errorf("failed to read a home flag: %w", err)
+			}
 
-		if _, err := os.Stat(homeDir); err == nil {
-			return fmt.Errorf("home dir(%v) already exists", homeDir)
-		} else if !os.IsNotExist(err) {
-			return fmt.Errorf("failed to check home dir: %w", err)
-		}
+			if _, err := os.Stat(homeDir); err == nil {
+				return fmt.Errorf("home dir(%v) already exists", homeDir)
+			} else if !os.IsNotExist(err) {
+				return fmt.Errorf("failed to check home dir: %w", err)
+			}
 
-		if err := os.MkdirAll(homeDir, os.ModePerm); err != nil {
-			return fmt.Errorf("failed to create config dir: %w", err)
-		}
+			if err := os.MkdirAll(homeDir, os.ModePerm); err != nil {
+				return fmt.Errorf("failed to create config dir: %w", err)
+			}
 
-		defaultConfig := config.DefaultConfig()
-		defaultConfig.SetHomeDir(homeDir)
+			defaultConfig := config.DefaultConfig()
+			defaultConfig.SetHomeDir(homeDir)
 
-		if err = os.MkdirAll(defaultConfig.AbsDataDirPath(), 0755); err != nil {
-			return fmt.Errorf("failed to create db dir: %w", err)
-		}
+			if err = os.MkdirAll(defaultConfig.AbsDataDirPath(), 0755); err != nil {
+				return fmt.Errorf("failed to create db dir: %w", err)
+			}
 
-		return config.WriteConfigTOML(getConfigPath(homeDir), defaultConfig)
-	},
+			return config.WriteConfigTOML(getConfigPath(homeDir), defaultConfig)
+		},
+	}
+	return cmd
 }
 
 func getConfigPath(homeDir string) string {

--- a/cmd/doracled/cmd/register_oracle.go
+++ b/cmd/doracled/cmd/register_oracle.go
@@ -70,8 +70,9 @@ func registerOracleCmd() *cobra.Command {
 			txBuilder := panacea.NewTxBuilder(*queryClient)
 			cli, err := panacea.NewGrpcClient(conf)
 			if err != nil {
-				return fmt.Errorf("failed to generate node key pair: %w", err)
+				return fmt.Errorf("failed to generate gRPC client: %w", err)
 			}
+			defer cli.Close()
 
 			defaultFeeAmount, _ := sdk.ParseCoinsNormalized(conf.Panacea.DefaultFeeAmount)
 			txBytes, err := txBuilder.GenerateSignedTxBytes(oracleAccount.GetPrivKey(), conf.Panacea.DefaultGasLimit, defaultFeeAmount, msgRegisterOracle)

--- a/cmd/doracled/cmd/root.go
+++ b/cmd/doracled/cmd/root.go
@@ -50,10 +50,10 @@ func init() {
 	rootCmd.PersistentFlags().String(flags.FlagHome, defaultAppHomeDir, "application home directory")
 
 	rootCmd.AddCommand(
-		initCmd,
+		initCmd(),
 		startCmd(),
-		genOracleKeyCmd,
-		verifyReport,
+		genOracleKeyCmd(),
+		verifyReportCmd(),
 		registerOracleCmd(),
 		getOracleKeyCmd(),
 	)

--- a/cmd/doracled/cmd/root.go
+++ b/cmd/doracled/cmd/root.go
@@ -55,7 +55,7 @@ func init() {
 		genOracleKeyCmd,
 		verifyReport,
 		registerOracleCmd(),
-		getOracleKeyCmd,
+		getOracleKeyCmd(),
 	)
 }
 

--- a/cmd/doracled/cmd/verify_report.go
+++ b/cmd/doracled/cmd/verify_report.go
@@ -10,26 +10,29 @@ import (
 	"io/ioutil"
 )
 
-var verifyReport = &cobra.Command{
-	Use:   "verify-report [report-file-path]",
-	Short: "Verify whether the report was properly generated in the SGX environment",
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		// read oracle remote targetReport
-		pubKeyInfo, err := readOracleRemoteReport(args[0])
-		if err != nil {
-			log.Errorf("failed to read remote targetReport: %v", err)
-			return err
-		}
+func verifyReportCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "verify-report [report-file-path]",
+		Short: "Verify whether the report was properly generated in the SGX environment",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// read oracle remote targetReport
+			pubKeyInfo, err := readOracleRemoteReport(args[0])
+			if err != nil {
+				log.Errorf("failed to read remote targetReport: %v", err)
+				return err
+			}
 
-		if err := verifyPubKeyRemoteReport(*pubKeyInfo); err != nil {
-			log.Errorf("failed to verify the public key and its remote report: %v", err)
-			return err
-		}
+			if err := verifyPubKeyRemoteReport(*pubKeyInfo); err != nil {
+				log.Errorf("failed to verify the public key and its remote report: %v", err)
+				return err
+			}
 
-		log.Infof("report verification success")
-		return nil
-	},
+			log.Infof("report verification success")
+			return nil
+		},
+	}
+	return cmd
 }
 
 func readOracleRemoteReport(filename string) (*OraclePubKeyInfo, error) {

--- a/panacea/query_client.go
+++ b/panacea/query_client.go
@@ -250,14 +250,7 @@ func (q QueryClient) GetStoreData(ctx context.Context, storeKey string, key []by
 }
 
 func (q QueryClient) Close() error {
-	err := q.sgxLevelDB.Close()
-	if err != nil {
-		return err
-	}
-
-	q.RpcClient.OnStop()
-
-	return nil
+	return q.sgxLevelDB.Close()
 }
 
 // Below are examples of query function that use GetStoreData function to verify queried result.

--- a/panacea/query_client.go
+++ b/panacea/query_client.go
@@ -86,7 +86,7 @@ func newQueryClient(ctx context.Context, config *config.Config, info *TrustedBlo
 	store := dbs.New(db, chainID)
 
 	var lc *light.Client
-	logger := light.Logger(tmlog.NewTMLogger(os.Stdout))
+	logger := light.Logger(tmlog.NewTMLogger(tmlog.NewSyncWriter(os.Stdout)))
 
 	if info == nil {
 		lc, err = light.NewClientFromTrustedStore(

--- a/panacea/query_client.go
+++ b/panacea/query_client.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/cosmos/cosmos-sdk/codec"
+	"os"
 	"sync"
 	"time"
 
@@ -40,6 +41,7 @@ type QueryClient struct {
 	sgxLevelDB  *sgxdb.SgxLevelDB
 	mutex       *sync.Mutex
 	cdc         *codec.ProtoCodec
+	chainID     string
 }
 
 // NewQueryClient set QueryClient with rpcClient & and returns, if successful,
@@ -84,6 +86,7 @@ func newQueryClient(ctx context.Context, config *config.Config, info *TrustedBlo
 	store := dbs.New(db, chainID)
 
 	var lc *light.Client
+	logger := light.Logger(tmlog.NewTMLogger(os.Stdout))
 
 	if info == nil {
 		lc, err = light.NewClientFromTrustedStore(
@@ -93,7 +96,7 @@ func newQueryClient(ctx context.Context, config *config.Config, info *TrustedBlo
 			pvs,
 			store,
 			light.SkippingVerification(light.DefaultTrustLevel),
-			light.Logger(tmlog.TestingLogger()),
+			logger,
 		)
 	} else {
 		trustOptions := light.TrustOptions{
@@ -109,7 +112,7 @@ func newQueryClient(ctx context.Context, config *config.Config, info *TrustedBlo
 			pvs,
 			store,
 			light.SkippingVerification(light.DefaultTrustLevel),
-			light.Logger(tmlog.TestingLogger()),
+			logger,
 		)
 	}
 
@@ -133,6 +136,7 @@ func newQueryClient(ctx context.Context, config *config.Config, info *TrustedBlo
 		sgxLevelDB:  db,
 		mutex:       &lcMutex,
 		cdc:         codec.NewProtoCodec(makeInterfaceRegistry()),
+		chainID:     chainID,
 	}, nil
 }
 

--- a/panacea/query_client_test.go
+++ b/panacea/query_client_test.go
@@ -218,7 +218,7 @@ func TestGetOracleRegistration(t *testing.T) {
 	// sign and broadcast to Panacea
 	msgRegisterOracle := oracletypes.NewMsgRegisterOracle(uniqueID, oracleAccount.GetAddress(), nodePubKey, nodePubKeyRemoteReport, trustedBlockinfo.TrustedBlockHeight, trustedBlockinfo.TrustedBlockHash)
 
-	txBuilder := panacea.NewTxBuilder(grpcClient)
+	txBuilder := panacea.NewTxBuilder(*queryClient)
 
 	defaultFeeAmount, _ := sdk.ParseCoinsNormalized("1500000umed")
 	txBytes, err := txBuilder.GenerateSignedTxBytes(oracleAccount.GetPrivKey(), 300000, defaultFeeAmount, msgRegisterOracle)

--- a/panacea/tx.go
+++ b/panacea/tx.go
@@ -17,11 +17,9 @@ type TxBuilder struct {
 }
 
 func NewTxBuilder(client QueryClient) *TxBuilder {
-	marshaller := client.cdc
-
 	return &TxBuilder{
 		client:     client,
-		marshaller: marshaller,
+		marshaller: client.cdc,
 	}
 }
 

--- a/panacea/tx.go
+++ b/panacea/tx.go
@@ -12,12 +12,12 @@ import (
 )
 
 type TxBuilder struct {
-	client     GrpcClientI
+	client     QueryClient
 	marshaller *codec.ProtoCodec
 }
 
-func NewTxBuilder(client GrpcClientI) *TxBuilder {
-	marshaller := codec.NewProtoCodec(client.GetInterfaceRegistry())
+func NewTxBuilder(client QueryClient) *TxBuilder {
+	marshaller := client.cdc
 
 	return &TxBuilder{
 		client:     client,
@@ -65,7 +65,7 @@ func (tb TxBuilder) GenerateSignedTxBytes(
 	}
 
 	signerData := authsigning.SignerData{
-		ChainID:       tb.client.GetChainID(),
+		ChainID:       tb.client.chainID,
 		AccountNumber: signerAccount.GetAccountNumber(),
 		Sequence:      signerAccount.GetSequence(),
 	}


### PR DESCRIPTION
convert grpc query that used in `register-oracle` and `get-oracle-key` commands to light client based query.

- change `TxBuilder` to `QueryClient`-based
- add flags to `get-oracle-key`
- change light client logger (TMLogger)