### PR TITLE
feat: add validate trusted block info when handling register oracle event

### DIFF
--- a/event/register_oracle_event.go
+++ b/event/register_oracle_event.go
@@ -1,6 +1,7 @@
 package event
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"fmt"
 	"github.com/btcsuite/btcd/btcec"
@@ -55,6 +56,15 @@ func (e RegisterOracleEvent) EventHandler(event ctypes.ResultEvent) error {
 	oracleRegistration, err := e.reactor.QueryClient().GetOracleRegistration(addressValue, uniqueID)
 	if err != nil {
 		return err
+	}
+
+	block, err := e.reactor.QueryClient().GetBlock(oracleRegistration.TrustedBlockHeight)
+	if err != nil {
+		return err
+	}
+
+	if !bytes.Equal(block.Hash().Bytes(), oracleRegistration.TrustedBlockHash) {
+		return fmt.Errorf("invalid trusted block info")
 	}
 
 	txBuilder := panacea.NewTxBuilder(*e.reactor.QueryClient())

--- a/event/register_oracle_event.go
+++ b/event/register_oracle_event.go
@@ -58,7 +58,7 @@ func (e RegisterOracleEvent) EventHandler(event ctypes.ResultEvent) error {
 		return err
 	}
 
-	block, err := e.reactor.QueryClient().GetBlock(oracleRegistration.TrustedBlockHeight)
+	block, err := e.reactor.QueryClient().GetLightBlock(oracleRegistration.TrustedBlockHeight)
 	if err != nil {
 		return err
 	}

--- a/panacea/query_client.go
+++ b/panacea/query_client.go
@@ -300,3 +300,12 @@ func (q QueryClient) GetOracleRegistration(oracleAddr, uniqueID string) (*oracle
 
 	return &oracleRegistration, nil
 }
+
+func (q QueryClient) GetBlock(height int64) (*tmtypes.Block, error) {
+	block, err := q.rpcClient.Block(context.Background(), &height)
+	if err != nil {
+		return nil, err
+	}
+
+	return block.Block, nil
+}

--- a/panacea/query_client.go
+++ b/panacea/query_client.go
@@ -301,11 +301,6 @@ func (q QueryClient) GetOracleRegistration(oracleAddr, uniqueID string) (*oracle
 	return &oracleRegistration, nil
 }
 
-func (q QueryClient) GetBlock(height int64) (*tmtypes.Block, error) {
-	block, err := q.rpcClient.Block(context.Background(), &height)
-	if err != nil {
-		return nil, err
-	}
-
-	return block.Block, nil
+func (q QueryClient) GetLightBlock(height int64) (*tmtypes.LightBlock, error) {
+	return q.lightClient.TrustedLightBlock(height)
 }


### PR DESCRIPTION
- Validating trusted block info when handling register oracle event.
- When the block hash different between blockchain and node that wants to register oracle, it returns an error.