### PR TITLE
feat: add trustedBlock info at gen-oracle-key when creating the genesis oracle

### DIFF
--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -2,7 +2,6 @@ package flags
 
 const (
 	FlagHome               = "home"
-	FlagIsGenesisOracle    = "is-genesis-oracle"
 	FlagTrustedBlockHeight = "trusted-block-height"
 	FlagTrustedBlockHash   = "trusted-block-hash"
 	FlagAccNum             = "acc-num"

--- a/client/flags/flags.go
+++ b/client/flags/flags.go
@@ -2,6 +2,7 @@ package flags
 
 const (
 	FlagHome               = "home"
+	FlagIsGenesisOracle    = "is-genesis-oracle"
 	FlagTrustedBlockHeight = "trusted-block-height"
 	FlagTrustedBlockHash   = "trusted-block-hash"
 	FlagAccNum             = "acc-num"

--- a/cmd/doracled/cmd/gen_oracle_key.go
+++ b/cmd/doracled/cmd/gen_oracle_key.go
@@ -82,7 +82,7 @@ So please be cautious in using this command.`,
 			if err != nil {
 				return err
 			}
-			if isGenesisOracle == true {
+			if isGenesisOracle {
 				// get trusted block information
 				trustedBlockInfo, err := getTrustedBlockInfo(cmd)
 				if err != nil {

--- a/cmd/doracled/cmd/gen_oracle_key.go
+++ b/cmd/doracled/cmd/gen_oracle_key.go
@@ -77,32 +77,26 @@ So please be cautious in using this command.`,
 				return err
 			}
 
-			// If FlagIsGenesisOracle is true, create a QueryClient
-			isGenesisOracle, err := cmd.Flags().GetBool(flags.FlagIsGenesisOracle)
+			// get trusted block information
+			trustedBlockInfo, err := getTrustedBlockInfo(cmd)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to get trusted block info: %w", err)
 			}
-			if isGenesisOracle {
-				// get trusted block information
-				trustedBlockInfo, err := getTrustedBlockInfo(cmd)
-				if err != nil {
-					return fmt.Errorf("failed to get trusted block info: %w", err)
-				}
 
-				// initialize query client using trustedBlockInfo
-				queryClient, err := panacea.NewQueryClient(context.Background(), conf, *trustedBlockInfo)
-				if err != nil {
-					return fmt.Errorf("failed to initialize QueryClient: %w", err)
-				}
-				defer queryClient.Close()
+			// initialize query client using trustedBlockInfo
+			queryClient, err := panacea.NewQueryClient(context.Background(), conf, *trustedBlockInfo)
+			if err != nil {
+				return fmt.Errorf("failed to initialize QueryClient: %w", err)
 			}
+			defer queryClient.Close()
 
 			return nil
 		},
 	}
-	cmd.Flags().Bool(flags.FlagIsGenesisOracle, false, "Check if it is the genesis oracle creation")
 	cmd.Flags().Int64(flags.FlagTrustedBlockHeight, 0, "Trusted block height")
 	cmd.Flags().String(flags.FlagTrustedBlockHash, "", "Trusted block hash")
+	_ = cmd.MarkFlagRequired(flags.FlagTrustedBlockHeight)
+	_ = cmd.MarkFlagRequired(flags.FlagTrustedBlockHash)
 
 	return cmd
 }

--- a/cmd/doracled/cmd/gen_oracle_key.go
+++ b/cmd/doracled/cmd/gen_oracle_key.go
@@ -2,9 +2,12 @@ package cmd
 
 import (
 	"bufio"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"github.com/medibloc/panacea-doracle/client/flags"
+	"github.com/medibloc/panacea-doracle/panacea"
 	"io/ioutil"
 	"os"
 
@@ -74,9 +77,33 @@ So please be cautious in using this command.`,
 				return err
 			}
 
+			// If FlagIsGenesisOracle is true, create a QueryClient
+			isGenesisOracle, err := cmd.Flags().GetBool(flags.FlagIsGenesisOracle)
+			if err != nil {
+				return err
+			}
+			if isGenesisOracle == true {
+				// get trusted block information
+				trustedBlockInfo, err := getTrustedBlockInfo(cmd)
+				if err != nil {
+					return fmt.Errorf("failed to get trusted block info: %w", err)
+				}
+
+				// initialize query client using trustedBlockInfo
+				queryClient, err := panacea.NewQueryClient(context.Background(), conf, *trustedBlockInfo)
+				if err != nil {
+					return fmt.Errorf("failed to initialize QueryClient: %w", err)
+				}
+				defer queryClient.Close()
+			}
+
 			return nil
 		},
 	}
+	cmd.Flags().Bool(flags.FlagIsGenesisOracle, false, "Check if it is the genesis oracle creation")
+	cmd.Flags().Int64(flags.FlagTrustedBlockHeight, 0, "Trusted block height")
+	cmd.Flags().String(flags.FlagTrustedBlockHash, "", "Trusted block hash")
+
 	return cmd
 }
 


### PR DESCRIPTION
To resolve the #49 issue, fix command `gen-oracle-key`.

- get trusted block info and initiate `QueryClient`