### PR TITLE
refactor: remove unused code

### DIFF
--- a/panacea/grpc_client.go
+++ b/panacea/grpc_client.go
@@ -3,43 +3,18 @@ package panacea
 import (
 	"context"
 	"fmt"
-	sdk "github.com/cosmos/cosmos-sdk/codec/types"
-	"github.com/cosmos/cosmos-sdk/std"
+
 	"github.com/cosmos/cosmos-sdk/types/tx"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
-	oracletypes "github.com/medibloc/panacea-core/v2/x/oracle/types"
 	"github.com/medibloc/panacea-doracle/config"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
-	"time"
 )
 
-type GrpcClientI interface {
-	Close() error
-	GetInterfaceRegistry() sdk.InterfaceRegistry
-	GetChainID() string
-	BroadcastTx([]byte) (*tx.BroadcastTxResponse, error)
-	GetAccount(string) (authtypes.AccountI, error)
-	GetOracleRegistration(string, string) (*oracletypes.OracleRegistration, error)
-}
-
-var _ GrpcClientI = (*GrpcClient)(nil)
-
 type GrpcClient struct {
-	conn              *grpc.ClientConn
-	interfaceRegistry sdk.InterfaceRegistry
-	chainID           string
+	conn *grpc.ClientConn
 }
 
-// makeInterfaceRegistry
-func makeInterfaceRegistry() sdk.InterfaceRegistry {
-	interfaceRegistry := sdk.NewInterfaceRegistry()
-	std.RegisterInterfaces(interfaceRegistry)
-	authtypes.RegisterInterfaces(interfaceRegistry)
-	return interfaceRegistry
-}
-
-func NewGrpcClient(conf *config.Config) (GrpcClientI, error) {
+func NewGrpcClient(conf *config.Config) (*GrpcClient, error) {
 	log.Infof("dialing to Panacea gRPC endpoint: %s", conf.Panacea.GRPCAddr)
 	conn, err := grpc.Dial(conf.Panacea.GRPCAddr, grpc.WithInsecure())
 	if err != nil {
@@ -47,57 +22,13 @@ func NewGrpcClient(conf *config.Config) (GrpcClientI, error) {
 	}
 
 	return &GrpcClient{
-		conn:              conn,
-		interfaceRegistry: makeInterfaceRegistry(),
-		chainID:           conf.Panacea.ChainID,
+		conn: conn,
 	}, nil
 }
 
 func (c *GrpcClient) Close() error {
 	log.Info("closing Panacea gRPC connection")
 	return c.conn.Close()
-}
-
-func (c *GrpcClient) GetInterfaceRegistry() sdk.InterfaceRegistry {
-	return c.interfaceRegistry
-}
-
-func (c *GrpcClient) GetChainID() string {
-	return c.chainID
-}
-
-func (c *GrpcClient) GetAccount(panaceaAddr string) (authtypes.AccountI, error) {
-	client := authtypes.NewQueryClient(c.conn)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-
-	response, err := client.Account(ctx, &authtypes.QueryAccountRequest{Address: panaceaAddr})
-	if err != nil {
-		return nil, fmt.Errorf("failed to get account info via grpc: %w", err)
-	}
-
-	var acc authtypes.AccountI
-	if err := c.interfaceRegistry.UnpackAny(response.GetAccount(), &acc); err != nil {
-		return nil, fmt.Errorf("failed to unpack account info: %w", err)
-	}
-	return acc, nil
-}
-
-func (c *GrpcClient) GetOracleRegistration(oracleAddr, uniqueID string) (*oracletypes.OracleRegistration, error) {
-	client := oracletypes.NewQueryClient(c.conn)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-
-	reqMsg := &oracletypes.QueryOracleRegistrationRequest{
-		UniqueId: uniqueID,
-		Address:  oracleAddr,
-	}
-	response, err := client.OracleRegistration(ctx, reqMsg)
-	if err != nil {
-		return nil, err
-	}
-
-	return response.OracleRegistration, nil
 }
 
 func (c *GrpcClient) BroadcastTx(txBytes []byte) (*tx.BroadcastTxResponse, error) {

--- a/panacea/query_client.go
+++ b/panacea/query_client.go
@@ -4,12 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/std"
+
 	"os"
 	"sync"
 	"time"
 
 	ics23 "github.com/confio/ics23/go"
+	sdk "github.com/cosmos/cosmos-sdk/codec/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	"github.com/cosmos/ibc-go/v2/modules/core/23-commitment/types"
 	oracletypes "github.com/medibloc/panacea-core/v2/x/oracle/types"
@@ -42,6 +46,14 @@ type QueryClient struct {
 	mutex       *sync.Mutex
 	cdc         *codec.ProtoCodec
 	chainID     string
+}
+
+// makeInterfaceRegistry
+func makeInterfaceRegistry() sdk.InterfaceRegistry {
+	interfaceRegistry := sdk.NewInterfaceRegistry()
+	std.RegisterInterfaces(interfaceRegistry)
+	authtypes.RegisterInterfaces(interfaceRegistry)
+	return interfaceRegistry
 }
 
 // NewQueryClient set QueryClient with rpcClient & and returns, if successful,

--- a/panacea/tx.go
+++ b/panacea/tx.go
@@ -2,7 +2,6 @@ package panacea
 
 import (
 	clienttx "github.com/cosmos/cosmos-sdk/client/tx"
-	"github.com/cosmos/cosmos-sdk/codec"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/bech32"
@@ -12,14 +11,12 @@ import (
 )
 
 type TxBuilder struct {
-	client     QueryClient
-	marshaller *codec.ProtoCodec
+	client QueryClient
 }
 
 func NewTxBuilder(client QueryClient) *TxBuilder {
 	return &TxBuilder{
-		client:     client,
-		marshaller: client.cdc,
+		client: client,
 	}
 }
 
@@ -30,7 +27,7 @@ func (tb TxBuilder) GenerateSignedTxBytes(
 	feeAmount sdk.Coins,
 	msg ...sdk.Msg,
 ) ([]byte, error) {
-	txConfig := authtx.NewTxConfig(tb.marshaller, []signing.SignMode{signing.SignMode_SIGN_MODE_DIRECT})
+	txConfig := authtx.NewTxConfig(tb.client.cdc, []signing.SignMode{signing.SignMode_SIGN_MODE_DIRECT})
 	txBuilder := txConfig.NewTxBuilder()
 	txBuilder.SetGasLimit(gasLimit)
 	txBuilder.SetFeeAmount(feeAmount)

--- a/service/service.go
+++ b/service/service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"fmt"
+
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/medibloc/panacea-doracle/config"
 	"github.com/medibloc/panacea-doracle/crypto"
@@ -67,7 +68,7 @@ func New(conf *config.Config, oracleAccount *panacea.OracleAccount) (*Service, e
 		oraclePrivKey: oraclePrivKey,
 		enclaveInfo:   selfEnclaveInfo,
 		queryClient:   queryClient,
-		grpcClient:    grpcClient.(*panacea.GrpcClient),
+		grpcClient:    grpcClient,
 		subscriber:    subscriber,
 	}, nil
 }


### PR DESCRIPTION
All the gRPC queries are replaced to light client query, so removed unused code.