### PR TITLE
fix: `SgxLevelDB.Get()` should return a `nil` value if the key is not found

### DIFF
--- a/store/sgxleveldb/db.go
+++ b/store/sgxleveldb/db.go
@@ -42,11 +42,14 @@ func (sdb *SgxLevelDB) Get(key []byte) ([]byte, error) {
 	val, err := sdb.GoLevelDB.Get(key)
 	if err != nil {
 		return nil, err
+	} else if val == nil {
+		return nil, nil
 	}
+
 	log.Debug("unsealing after reading from leveldb")
 	unsealedVal, err := sgx.Unseal(val, true)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unseal value from leveldb: %w", err)
 	}
 
 	return unsealedVal, nil


### PR DESCRIPTION
Closes #65 