### PR TITLE
fix: handle the cases when `rpcClient.ABCIQueryWithOptions()` returns invalid responses

### DIFF
--- a/panacea/query_client.go
+++ b/panacea/query_client.go
@@ -286,6 +286,9 @@ func (q QueryClient) abciQueryWithOptions(ctx context.Context, path string, data
 	if len(resp.Key) == 0 {
 		return nil, errors.New("empty key")
 	}
+	if len(resp.Value) == 0 {
+		return nil, errors.New("empty value")
+	}
 	if opts.Prove && (resp.ProofOps == nil || len(resp.ProofOps.Ops) == 0) {
 		return nil, errors.New("no proof ops")
 	}

--- a/panacea/query_client.go
+++ b/panacea/query_client.go
@@ -290,7 +290,7 @@ func (q QueryClient) abciQueryWithOptions(ctx context.Context, path string, data
 		return nil, errors.New("no proof ops")
 	}
 	if resp.Height <= 0 {
-		return nil, fmt.Errorf("negative or zero height")
+		return nil, errors.New("negative or zero height")
 	}
 
 	return res, nil

--- a/panacea/query_client.go
+++ b/panacea/query_client.go
@@ -23,6 +23,7 @@ import (
 	"github.com/medibloc/panacea-doracle/config"
 	sgxdb "github.com/medibloc/panacea-doracle/store/sgxleveldb"
 	log "github.com/sirupsen/logrus"
+	tmbytes "github.com/tendermint/tendermint/libs/bytes"
 	tmlog "github.com/tendermint/tendermint/libs/log"
 	"github.com/tendermint/tendermint/light"
 	"github.com/tendermint/tendermint/light/provider"
@@ -30,6 +31,7 @@ import (
 	dbs "github.com/tendermint/tendermint/light/store/db"
 	"github.com/tendermint/tendermint/rpc/client"
 	rpchttp "github.com/tendermint/tendermint/rpc/client/http"
+	ctypes "github.com/tendermint/tendermint/rpc/core/types"
 	tmtypes "github.com/tendermint/tendermint/types"
 )
 
@@ -221,7 +223,7 @@ func (q QueryClient) GetStoreData(ctx context.Context, storeKey string, key []by
 		Height: queryHeight,
 	}
 	// query to kv store with proof option
-	result, err := q.rpcClient.ABCIQueryWithOptions(ctx, fmt.Sprintf("/store/%s/key", storeKey), key, option)
+	result, err := q.abciQueryWithOptions(ctx, fmt.Sprintf("/store/%s/key", storeKey), key, option)
 	if err != nil {
 		return nil, err
 	}
@@ -266,6 +268,32 @@ func (q QueryClient) GetStoreData(ctx context.Context, storeKey string, key []by
 
 func (q QueryClient) Close() error {
 	return q.sgxLevelDB.Close()
+}
+
+// abciQueryWithOptions is a wrapper of rpcClient.ABCIQueryWithOptions,
+// but validates the details of result.Response even if rpcClient.ABCIQueryWithOptions returns no error.
+func (q QueryClient) abciQueryWithOptions(ctx context.Context, path string, data tmbytes.HexBytes, opts client.ABCIQueryOptions) (*ctypes.ResultABCIQuery, error) {
+	res, err := q.rpcClient.ABCIQueryWithOptions(ctx, path, data, opts)
+	if err != nil {
+		return nil, err
+	}
+	resp := res.Response
+
+	// Validate the response.
+	if resp.IsErr() {
+		return nil, fmt.Errorf("err response code: %v", resp.Code)
+	}
+	if len(resp.Key) == 0 {
+		return nil, errors.New("empty key")
+	}
+	if opts.Prove && (resp.ProofOps == nil || len(resp.ProofOps.Ops) == 0) {
+		return nil, errors.New("no proof ops")
+	}
+	if resp.Height <= 0 {
+		return nil, fmt.Errorf("negative or zero height")
+	}
+
+	return res, nil
 }
 
 // Below are examples of query function that use GetStoreData function to verify queried result.


### PR DESCRIPTION
Closes #67 

Initially, I tried to fix this code as below:
```go
result, err := q.rpcClient.ABCIQueryWithOptions(ctx, fmt.Sprintf("/store/%s/key", storeKey), key, option)
if err != nil {
    return nil, err
} else if result.Response.Value == nil || result.Response.ProofOps == nil {
    return nil, fmt.Errorf("ABCIQuery returned NotFound")
}
```
But, I've found there are still many edge cases that we should handle. I referred to the code in Tendermint: https://github.com/tendermint/tendermint/blob/0c96f0b434c1d9f23883d1f2291135830a7a5290/light/rpc/client.go#L139.
I was thinking of just using Tendermint's implementation directly, but couldn't figure it if it would work or not in our codebase. So, for now, I just copied their code blocks to our codebase.