### PR TITLE
fix: handle base64 values returned by Panacea properly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/cosmos/go-bip39 v1.0.0
 	github.com/cosmos/ibc-go/v2 v2.0.3
 	github.com/edgelesssys/ego v1.0.0
-	github.com/medibloc/panacea-core/v2 v2.1.0-alpha2.0.20220915052104-fd4a0ce6c4fb
+	github.com/medibloc/panacea-core/v2 v2.1.0-alpha2.0.20220916060638-9a0c908458a3
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.5.0
 	github.com/spf13/viper v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -669,6 +669,8 @@ github.com/medibloc/panacea-core/v2 v2.1.0-alpha2.0.20220915010659-2c0f80b0f08e 
 github.com/medibloc/panacea-core/v2 v2.1.0-alpha2.0.20220915010659-2c0f80b0f08e/go.mod h1:l9fOSt3J2e5jUKrMnd/wD6etXymvoKbByW5f2V4gZu4=
 github.com/medibloc/panacea-core/v2 v2.1.0-alpha2.0.20220915052104-fd4a0ce6c4fb h1:GS1F3IMe//m6yMHow/wNS/e9gNS/60rDFMXT5Aq8qVQ=
 github.com/medibloc/panacea-core/v2 v2.1.0-alpha2.0.20220915052104-fd4a0ce6c4fb/go.mod h1:l9fOSt3J2e5jUKrMnd/wD6etXymvoKbByW5f2V4gZu4=
+github.com/medibloc/panacea-core/v2 v2.1.0-alpha2.0.20220916060638-9a0c908458a3 h1:lK22vM7PJrqB8Qey0SOxxPGNlby5gf7Aff0Xaezt92s=
+github.com/medibloc/panacea-core/v2 v2.1.0-alpha2.0.20220916060638-9a0c908458a3/go.mod h1:l9fOSt3J2e5jUKrMnd/wD6etXymvoKbByW5f2V4gZu4=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=

--- a/panacea/query_client.go
+++ b/panacea/query_client.go
@@ -2,6 +2,7 @@ package panacea
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 
@@ -321,18 +322,19 @@ func (q QueryClient) GetLightBlock(height int64) (*tmtypes.LightBlock, error) {
 }
 
 func (q QueryClient) GetOracleParamsPublicKey() (*btcec.PublicKey, error) {
-	oraclePubKeyBz, err := q.GetStoreData(context.Background(), paramstypes.StoreKey, append(append([]byte(oracletypes.StoreKey), '/'), oracletypes.KeyOraclePublicKey...))
+	pubKeyBase64Bz, err := q.GetStoreData(context.Background(), paramstypes.StoreKey, append(append([]byte(oracletypes.StoreKey), '/'), oracletypes.KeyOraclePublicKey...))
 	if err != nil {
 		return nil, err
 	}
-	if oraclePubKeyBz == nil {
+	// TODO: don't need to handle this case after merging https://github.com/medibloc/panacea-doracle/pull/68
+	if pubKeyBase64Bz == nil {
 		return nil, errors.New("the oracle public key's value is nil")
 	}
 
-	oraclePubKey, err := btcec.ParsePubKey(oraclePubKeyBz, btcec.S256())
+	pubKeyBz, err := base64.StdEncoding.DecodeString(string(pubKeyBase64Bz))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to decode base64 pubkey: %w", err)
 	}
 
-	return oraclePubKey, nil
+	return btcec.ParsePubKey(pubKeyBz, btcec.S256())
 }


### PR DESCRIPTION
Close #69 

But, this code won't work well before resolving https://github.com/medibloc/panacea-core/issues/406, because the returned `[]byte` from panacea-core is actually `[]byte("\"value\"")` (with double quotations) for some reason. I guess it's the way how Protobuf encodes a `string` value to a `bytes`.
If you run this code without changing anything in panacea-core, you will get an error:
```
illegal base64 data at input byte 0
```
, because the first character `"` is not in the base64 charset.

To resolve this issue, I've made the PR https://github.com/medibloc/panacea-core/pull/407.