### PR TITLE
ci: separate the Lint job with the main job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,13 +13,13 @@ jobs:
 
     steps:
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
         id: go
 
       - name: Checkout code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Build
         env:
@@ -34,7 +34,22 @@ jobs:
       - name: Sign the binary with EGo for production
         run: make sign-prod
 
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
+        id: go
+
+      - name: Checkout code into the Go module directory
+        uses: actions/checkout@v3
+
       - name: Lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.30
+          version: latest
+          args: --timeout=5m


### PR DESCRIPTION
Because golangci-lint eats lots of memory, I'd like to separate the Lint job with the main job. The main job will be run on the self-hosted runner as it is. The Lint job will be run on the Github-hosted runner. It will reduce the cost of our self-hosted machine.

FYI, I used the latest version of golangci-lint which fixes some unexpected errors. For that, I had to bump the version of `actions/setup-go` and `actions/checkout`. 

FYI, I will rebase my PR #56 to this PR.