### PR TITLE
feat: add certificate to verify a TLS server

### DIFF
--- a/scripts/enclave-prod.json
+++ b/scripts/enclave-prod.json
@@ -24,5 +24,10 @@
       "value": "/home_mnt"
     }
   ],
-  "files": null
+  "files": [
+    {
+      "source": "/etc/ssl/certs/ca-certificates.crt",
+      "target": "/etc/ssl/certs/ca-certificates.crt"
+    }
+  ]
 }


### PR DESCRIPTION
embed root certificates in the `enclave.json`
- Added to enable https connections in the `deal` `data_schema` inside the enclave.
(e.g https://json.schemastore.org/github-issue-forms.json)
- This is for the `ValidateJSONSchemata` work correctly